### PR TITLE
Armor.xml

### DIFF
--- a/Armor.xml
+++ b/Armor.xml
@@ -927,43 +927,43 @@
 	
 	<!-- Dragon Priest Masks start -->
 		<binding>
-			<identifier>Dwarven</identifier>
+			<identifier>DwarvenHigh</identifier>
 			<substring>Konahrik</substring>
 		</binding>
 		<binding>
-			<identifier>Dwarven</identifier>
+			<identifier>DwarvenHigh</identifier>
 			<substring>Konahrik Circlet</substring>
 		</binding>
 		<binding>
-			<identifier>Glass</identifier>
+			<identifier>GoldHeavy</identifier>
 			<substring>Otar</substring>
 		</binding>
 		<binding>
-			<identifier>Glass</identifier>
+			<identifier>GoldHeavy</identifier>
 			<substring>Otar Circlet</substring>
 		</binding>
 		<binding>
-			<identifier>Iron</identifier>
+			<identifier>IronHigh</identifier>
 			<substring>Hevnoraak</substring>
 		</binding>
 		<binding>
-			<identifier>Iron</identifier>
+			<identifier>IronHigh</identifier>
 			<substring>Hevnoraak Circlet</substring>
 		</binding>
 		<binding>
-			<identifier>Steel Plate</identifier>
+			<identifier>Silver</identifier>
 			<substring>Vokun</substring>
 		</binding>
 		<binding>
-			<identifier>Steel Plate</identifier>
+			<identifier>Silver</identifier>
 			<substring>Vokun Circlet</substring>
 		</binding>
 		<binding>
-			<identifier>Orcish</identifier>
+			<identifier>OrcishLight</identifier>
 			<substring>Rahgot</substring>
 		</binding>
 		<binding>
-			<identifier>Orcish</identifier>
+			<identifier>OrcishLight</identifier>
 			<substring>Rahgot Circlet</substring>
 		</binding>
 		<binding>
@@ -975,32 +975,44 @@
 			<substring>Nahkriin Circlet</substring>
 		</binding>
 		<binding>
-			<identifier>Scaled</identifier>
+			<identifier>ScaledHigh</identifier>
 			<substring>Volsung</substring>
 		</binding>
 		<binding>
-			<identifier>Scaled</identifier>
+			<identifier>ScaledHigh</identifier>
 			<substring>Volsung Circlet</substring>
 		</binding>
 		<binding>
-			<identifier>Elven</identifier>
+			<identifier>Glass</identifier>
 			<substring>Morokei</substring>
 		</binding>
 		<binding>
-			<identifier>Elven</identifier>
+			<identifier>Glass</identifier>
 			<substring>Morokei Circlet</substring>
 		</binding>
 		<binding>
-			<identifier>Elven</identifier>
+			<identifier>ElvenHigh</identifier>
 			<substring>Krosis</substring>
 		</binding>
 		<binding>
-			<identifier>Elven</identifier>
+			<identifier>ElvenHigh</identifier>
 			<substring>Krosis Circlet</substring>
 		</binding>
 		<binding>
 			<identifier>Daedric</identifier>
 			<substring>Miraak</substring>
+		</binding>
+		<binding>
+			<identifier>ScaledHeavy</identifier>
+			<substring>Ahzidal</substring>
+		</binding>
+		<binding>
+			<identifier>HNordicHigh</identifier>
+			<substring>Dukaan</substring>
+		</binding>
+		<binding>
+			<identifier>EbonyLight</identifier>
+			<substring>Zahkriisos</substring>
 		</binding>
 	<!-- Dragon Priest Masks end -->
 	


### PR DESCRIPTION
I noticed that 3 of the 4 Dragon Priest masks added by Dragonborn were missing from the XML, so I added them and reworked the rest for balance. Priorities: 1) maintain an equal number of heavy and light masks, 2) ensure that the material type matches the mask's coloration, and 3) make Dragon Priest masks preferable to most low- and mid-tier armor types (in accordance with their status as high-level artifacts).

TL;DR I added missing masks.
