### PR TITLE
Immersive weapons colovian bow typo

### DIFF
--- a/Weapons.xml
+++ b/Weapons.xml
@@ -3592,7 +3592,7 @@
 		</binding>
 		<binding>
 			<identifier>Ashwood</identifier>
-			<substring>Dark Colovian Composite Bow</substring>
+			<substring>Colovian Dark Composite Bow</substring>
 		</binding>
 	<!-- Wood bindings end -->
 	</weapon_material_bindings>


### PR DESCRIPTION
Just fixed a small typo.

I experimented with making the light/dark naming change in the Immersive Weapons.esp to make PaMa pick up the changes, but I ended up liking your Oakwood/Ashwood approach better.

The only thing missing is to make the Dark version drop a steel ingot just like the vanilla Imperial Bow, but I don't see a steel binding that multiplies with 1.1? The closest is SteelHigh for 1.05, right?
