### PR TITLE
Deadly Trio (Partial) and Lord's Mail

### DIFF
--- a/Armor.xml
+++ b/Armor.xml
@@ -8629,5 +8629,12 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- B-D-Y-E-B -->
+	<!-- Lord's Mail -->
+		<exclusion>
+			<text>LM_</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Lord's Mail -->
 	</reforge_exclusions>
 </ns2:armor>

--- a/Armor.xml
+++ b/Armor.xml
@@ -3214,6 +3214,10 @@
 			<identifier>ElvenHigh</identifier>
 			<substring>Electrum Elven</substring>
 		</binding>
+		<binding>
+			<identifier>ElvenHigh</identifier>
+			<substring>Sword Master</substring>
+		</binding>
 	<!-- Elven Material Bindings end -->
 	
 	<!-- Falmer Material Bindings start -->
@@ -4881,6 +4885,10 @@
 		<binding>
 			<identifier>Leather</identifier>
 			<substring>Oiled Mail Hauberk</substring>
+		</binding>
+		<binding>
+			<identifier>LeatherHigh</identifier>
+			<substring>Witch Hunter</substring>
 		</binding>
 	<!-- Leather Material Bindings end -->
 	

--- a/Armor.xml
+++ b/Armor.xml
@@ -2894,6 +2894,10 @@
 			<identifier>Ebony</identifier>
 			<substring>Bulwark of Azzinoth</substring>
 		</binding>
+		<binding>
+			<identifier>Ebony</identifier>
+			<substring>Lord's Mail</substring>
+		</binding>
 	<!-- Ebony Material Bindings end -->
 	
 	<!-- Elven Material Bindings start -->

--- a/Enchanting.xml
+++ b/Enchanting.xml
@@ -8518,6 +8518,23 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Lord's Mail -->
+	<!-- Deadly Trio -->
+		<exclusion>
+			<text>xxxSwordMaster</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+		<exclusion>
+			<text>xxxWitchHunter</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+		<exclusion>
+			<text>xxxVampireHunter</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Deadly Trio -->
 	</enchantment_armor_exclusions>
 
 	<similarity_exclusions_armor>

--- a/Enchanting.xml
+++ b/Enchanting.xml
@@ -8511,6 +8511,13 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Jethead Armors -->
+	<!-- Lord's Mail -->
+		<exclusion>
+			<text>LM</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Lord's Mail -->
 	</enchantment_armor_exclusions>
 
 	<similarity_exclusions_armor>

--- a/LeveledLists.xml
+++ b/LeveledLists.xml
@@ -6987,6 +6987,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Jethead Armors -->
+		<!-- Lord's Mail -->
+			<exclusion>
+				<text>LM</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Lord's Mail -->
 		</distribution_exclusions_armor_enchanted>
 
 		<distribution_exclusions_list_enchanted>

--- a/LeveledLists.xml
+++ b/LeveledLists.xml
@@ -5608,6 +5608,23 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Jethead Armors -->
+		<!-- Deadly Trio -->
+			<exclusion>
+				<text>xxxSwordMaster</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+			<exclusion>
+				<text>xxxWitchHunter</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+			<exclusion>
+				<text>xxxVampireHunter</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Deadly Trio -->
 		</distribution_exclusions_armor_regular>
 
 		<distribution_exclusions_list_regular>


### PR DESCRIPTION
Deadly Trio's Vampire Hunter armor could not be bonded to the proper ArmorMaterial as there was a preexisting entry for Vampire Hunter with SteelLight Armor Material
Lords Mail was added to reforge exclusions as it was enchanted, despite being temperable.
