### PR TITLE
Mod Additions

### DIFF
--- a/Armor.xml
+++ b/Armor.xml
@@ -2446,6 +2446,10 @@
 			<identifier>Dwarven</identifier>
 			<substring>Last Hope</substring><!-- Same name is used for a Elven Shield -->
 		</binding>
+		<binding>
+			<identifier>Dwarven</identifier>
+			<substring>Markarth Silverblood</substring>
+		</binding>
 	<!-- Dwarven Material Bindings end -->
 	
 	<!-- Ebony Material Bindings start -->
@@ -4938,6 +4942,10 @@
 			<identifier>LeatherHigh</identifier>
 			<substring>Mord Sith</substring>
 		</binding>
+		<binding>
+			<identifier>LeatherHigh</identifier>
+			<substring>Savage Hunter</substring>
+		</binding>
 	<!-- Leather Material Bindings end -->
 	
 	<!-- None Material Listings start -->
@@ -5742,6 +5750,10 @@
 			<identifier>ScaledHigh</identifier>
 			<substring>Tembtra Thief Reinforced Tunic</substring>
 		</binding>
+		<binding>
+			<identifier>ScaledHigh</identifier>
+			<substring>Riften Nightwatch</substring>
+		</binding>
 	<!-- Scaled Material Bindings end -->
 	
 	<!-- Silver Material Bindings start -->
@@ -6509,6 +6521,14 @@
 		<binding>
 			<identifier>Steel Plate</identifier>
 			<substring>Black Archmage Plate Armor (H)</substring>
+		</binding>
+		<binding>
+			<identifier>Steel Plate</identifier>
+			<substring>Solitude Infantry</substring>
+		</binding>
+		<binding>
+			<identifier>Steel Plate</identifier>
+			<substring>Windhelm Steel</substring>
 		</binding>
 	<!-- Steel Plate Material Bindings end -->
 	

--- a/Armor.xml
+++ b/Armor.xml
@@ -2022,6 +2022,14 @@
 			<identifier>Dragonplate</identifier>
 			<substring>Dragonsteel</substring>
 		</binding>
+		<binding>
+			<identifier>Dragonplate</identifier>
+			<substring>Knight Of Thorns</substring>
+		</binding>
+		<binding>
+			<identifier>Dragonplate</identifier>
+			<substring>Knight Thorns</substring>
+		</binding>
 	<!-- Dragonplate Material Bindings end -->
 	
 	<!-- Dragonscale Material Bindings start -->
@@ -3217,6 +3225,10 @@
 		<binding>
 			<identifier>ElvenHigh</identifier>
 			<substring>Electrum Elven</substring>
+		</binding>
+		<binding>
+			<identifier>ElvenHigh</identifier>
+			<substring>Sword Master</substring>
 		</binding>
 	<!-- Elven Material Bindings end -->
 	
@@ -4914,6 +4926,18 @@
 			<identifier>Leather</identifier>
 			<substring>Ranger Boots</substring>
 		</binding>
+		<binding>
+			<identifier>LeatherHigh</identifier>
+			<substring>Witch Hunter</substring>
+		</binding>
+		<binding>
+			<identifier>LeatherHigh</identifier>
+			<substring>Vampire Hunter</substring>
+		</binding>
+		<binding>
+			<identifier>LeatherHigh</identifier>
+			<substring>Mord Sith</substring>
+		</binding>
 	<!-- Leather Material Bindings end -->
 	
 	<!-- None Material Listings start -->
@@ -6561,10 +6585,6 @@
 		<binding>
 			<identifier>Vampire</identifier>
 			<substring>Cowl of Midnight</substring>
-		</binding>
-		<binding>
-			<identifier>SteelLight</identifier>
-			<substring>Vampire Hunter</substring>
 		</binding>
 		<binding>
 			<identifier>Vampire</identifier>
@@ -8658,5 +8678,33 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- B-D-Y-E-B -->
+	<!-- Lord's Mail -->
+		<exclusion>
+			<text>LM_</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Lord's Mail -->
+	<!-- Knight of Thorns Armor and Spear of Thorns -->
+		<exclusion>
+			<text>ArmorThorns</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Knight of Thorns Armor and Spear of Thorns -->
+	<!-- Mord Sith Cara Armor -->
+		<exclusion>
+			<text>xxxMordSith</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Mord Sith Cara Armor -->
+	<!-- Draconic Bloodline -->
+		<exclusion>
+			<text>DBL</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Draconic Bloodline -->
 	</reforge_exclusions>
 </ns2:armor>

--- a/Enchanting.xml
+++ b/Enchanting.xml
@@ -7495,6 +7495,13 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Skyrim Sewers 4 -->
+	<!--Knight of Thorns Armor and Spear of Thorns-->
+		<exclusion>
+			<text>ThornsSpear</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!--Knight of Thorns Armor and Spear of Thorns-->
 	</enchantment_weapon_exclusions>
 
 	<enchantment_armor_exclusions>
@@ -8518,6 +8525,51 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Grace Darklings Ranger Armor -->
+	<!-- Lord's Mail -->
+		<exclusion>
+			<text>LM</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Lord's Mail -->
+	<!-- Deadly Trio -->
+		<exclusion>
+			<text>xxxSwordMaster</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+		<exclusion>
+			<text>xxxWitchHunter</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+		<exclusion>
+			<text>xxxVampireHunter</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Deadly Trio -->
+	<!-- Knight of Thorns armor and Spear of Thorns -->
+		<exclusion>
+			<text>ArmorThorns</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Knight of Thorns armor and Spear of Thorns -->
+	<!-- Mord Sith Cara Armor -->
+		<exclusion>
+			<text>xxxMordSith</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Mord Sith Cara Armor -->
+	<!-- Draconic Bloodline -->
+		<exclusion>
+			<text>DBL</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Draconic Bloodline -->
 	</enchantment_armor_exclusions>
 
 	<similarity_exclusions_armor>

--- a/Enchanting.xml
+++ b/Enchanting.xml
@@ -8570,6 +8570,13 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Draconic Bloodline -->
+	<!-- Omegared99 - Gallery of Armor -->
+		<exclusion>
+			<text>099</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Omegared99 - Gallery of Armor -->
 	</enchantment_armor_exclusions>
 
 	<similarity_exclusions_armor>

--- a/LeveledLists.xml
+++ b/LeveledLists.xml
@@ -5786,6 +5786,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Draconic Bloodline -->
+		<!-- Omegared99 - Gallery of Armor -->
+			<exclusion>
+				<text>099</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Omegared99 - Gallery of Armor -->
 		</distribution_exclusions_armor_regular>
 
 		<distribution_exclusions_list_regular>

--- a/LeveledLists.xml
+++ b/LeveledLists.xml
@@ -1062,6 +1062,13 @@
 				<type>EQUALS</type>
 			</exclusion>
 		<!-- Tembtra Thief Armor -->
+		<!-- Draconic Bloodline -->
+			<exclusion>
+				<text>DBL</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Draconic Bloodline -->
 		</distribution_exclusions_spell>
 
 		<distribution_exclusions_book>
@@ -1637,6 +1644,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Tembtra Thief Armor -->
+		<!-- Draconic Bloodline -->
+			<exclusion>
+				<text>DBL</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Draconic Bloodline -->
 		</distribution_exclusions_book>
 
 		<distribution_exclusions_list>
@@ -3064,6 +3078,13 @@
 				<type>CONTAINS</type>
 			</exclusion>
 		<!-- Diverse Bows -->
+		<!-- Knight of Thorns Armor and Spear of Thorns -->
+			<exclusion>
+				<text>ThornsSpear</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Knight of Thorns Armor and Spear of Thorns -->
 		</distribution_exclusions_weapon_regular>
 
 		<distribution_exclusions_list_regular>
@@ -5727,6 +5748,44 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Grace Darklings Ranger Armor -->
+		<!-- Deadly Trio -->
+			<exclusion>
+				<text>xxxSwordMaster</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+			<exclusion>
+				<text>xxxWitchHunter</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+			<exclusion>
+				<text>xxxVampireHunter</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Deadly Trio -->
+		<!-- Knight of Thorns Armor and Spear of Thorns -->
+			<exclusion>
+				<text>ArmorThorns</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Knight of Thorns Armor and Spear of Thorns -->
+		<!-- Mord Sith Cara Armor -->
+			<exclusion>
+				<text>xxxMordSith</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Mord Sith Cara Armor -->
+		<!-- Draconic Bloodline -->
+			<exclusion>
+				<text>DBL</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Draconic Bloodline -->
 		</distribution_exclusions_armor_regular>
 
 		<distribution_exclusions_list_regular>
@@ -7113,6 +7172,20 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Everybodys Different -->
+		<!-- Lord's Mail -->
+			<exclusion>
+				<text>LM</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Lord's Mail -->
+		<!-- Draconic Bloodline -->
+			<exclusion>
+				<text>DBL</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Draconic Bloodline -->
 		</distribution_exclusions_armor_enchanted>
 
 		<distribution_exclusions_list_enchanted>

--- a/Weapons.xml
+++ b/Weapons.xml
@@ -2182,6 +2182,10 @@
 			<identifier>Ebony</identifier>
 			<substring>Ebonsteel</substring>
 		</binding>
+		<binding>
+			<identifier>EbonyHigh</identifier>
+			<substring>Spear of Thorns</substring>
+		</binding>
 	<!-- Ebony bindings end -->
 	
 	<!-- Elven bindings start -->
@@ -3066,6 +3070,10 @@
 		<binding>
 			<identifier>SilverHigh</identifier>
 			<substring>Mournbringer</substring>
+		</binding>
+		<binding>
+			<identifier>SilverHigh</identifier>
+			<substring>Mithrodin</substring>
 		</binding>
 	<!-- Silver bindings end -->
 	
@@ -5227,6 +5235,10 @@
 			<substring>Uznahgaar</substring>
 			<identifier>Arming Sword</identifier>
 		</binding>
+		<binding>
+			<substring>Mithrodin I</substring>
+			<identifier>Arming Sword</identifier>
+		</binding>
 	<!-- Arming Sword bindings end -->
 
 	<!-- Broadsword bindings start -->
@@ -6650,6 +6662,10 @@
 			<substring>Blade of the Rourken</substring>
 			<identifier>Greatsword</identifier>
 		</binding>
+		<binding>
+			<substring>Mithrodin II</substring>
+			<identifier>Greatsword</identifier>
+		</binding>
 	<!-- Greatsword bindings end -->
 	
 	<!-- Halberd bindings start -->
@@ -6732,6 +6748,10 @@
 		</binding>
 		<binding>
 			<identifier>Trident</identifier>
+			<substring>Partisan</substring>
+		</binding>
+		<binding>
+			<identifier>Spear Of Thorns</identifier>
 			<substring>Partisan</substring>
 		</binding>
 	<!-- Partisan bindings end -->
@@ -8457,6 +8477,13 @@
 			<type>CONTAINS</type>
 		</exclusion>
 	<!-- Skyrim Knights -->
+	<!-- Knight of Thorns Armor and Spear of Thorns -->
+		<exclusion>
+			<text>ThornsSpear</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Knight of Thorns Armor and Spear of Thorns -->
 	</reforge_exclusions>
 
 </ns2:weapons>


### PR DESCRIPTION
Added Omegared99 - Gallery of Armor -added enchantment and Leveled list exclusions despite lack of authors distribution due to 2 reasons: 1. The names of the armors are very area Specific 2. The author links and recommends a distribution patch on his main page.
Added Mord Sith Cara Armor
Added Lord's Mail exclusions - These are for the solo lord's armor added by http://www.nexusmods.com/skyrim/mods/40497/? The Morrowloot 4e edition has different stats and material, but the exclusions may as well be added.
Added Knight of Thorns armor and Knight of thorns Spear - Spear has much more in common with a Partisian than it does with a regular spear as it is 2h and has a three pronged tip
Added Draconic Bloodline -All armors besides the clothing had names that did not need patching, so just added armor/enchant/reforge/book exclusions
Added Deadly Trio -Changed Vampire Hunter from SteelLight to LeatherHigh, Sands of time is the one that previously bound this armor to SteelLight, However, upon looking at the sands of Time esp, the armor is clearly glass(matching meshes/armor rating) and aforementioned material bindings are very strange, so unless thats changed I believe its more sensible to compromise and give the proper material bindings for deadly trio, as its keywords make more sense.
