### PR TITLE
Added Much Ado about Snow Elves - A Tragedy - Act I

### DIFF
--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Ammunition.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Ammunition.xml
@@ -395,6 +395,14 @@
 			<gravityModifier>0.35</gravityModifier>
 			<multiply>true</multiply>
 		</ammunition_material>
+		<ammunition_material>
+			<identifier>Ancient Falmer</identifier>
+			<damageModifier>9</damageModifier>
+			<rangeModifier>0</rangeModifier>
+			<speedModifier>200</speedModifier>
+			<gravityModifier>0.16</gravityModifier>
+			<multiply>true</multiply>
+		</ammunition_material>
 	<!-- Heavy materials -->
 		<ammunition_material>
 			<identifier>Iron</identifier>
@@ -953,6 +961,12 @@
 			<substring>Black Dragon</substring>
 		</binding>
 	<!-- Compound Bow Collection-Redux -->
+	<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
+		<binding>
+			<identifier>Ancient Falmer</identifier>
+			<substring>Ancient Falmer</substring>
+		</binding>
+	<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
 	</ammunition_material_bindings>
 
 	<ammunition_exclusions_multiplication>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
@@ -3108,10 +3108,6 @@
 		</binding>
 		<binding>
 			<identifier>Elven</identifier>
-			<substring>Jalamark</substring>
-		</binding>
-		<binding>
-			<identifier>Elven</identifier>
 			<substring>Spellsword</substring>
 		</binding>
 		<binding>
@@ -3317,6 +3313,10 @@
 		<binding>
 			<identifier>Falmer Hardened</identifier>
 			<substring>Falmer Circlet</substring>
+		</binding>
+		<binding>
+			<identifier>Ancient Falmer</identifier>
+			<substring>SunBlessed</substring>
 		</binding>
 	<!-- Falmer Material Bindings end -->
 	
@@ -8801,5 +8801,12 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- aMidianBorn_ContentAddon -->
+	<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
+		<exclusion>
+			<text>SunBlessed</text>
+			<target>NAME</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
 	</reforge_exclusions>
 </ns2:armor>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
@@ -7565,7 +7565,12 @@
 	<!-- Sovereign's Slayer Armor -->
 	<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
 		<exclusion>
-			<text>LB_</text>
+			<text>LB_Steel</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+		<exclusion>
+			<text>LB_Orcish</text>
 			<target>EDID</target>
 			<type>STARTSWITH</type>
 		</exclusion>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
@@ -7563,6 +7563,13 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Sovereign's Slayer Armor -->
+	<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
+		<exclusion>
+			<text>LB_</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
 	</enchantment_weapon_exclusions>
 
 	<enchantment_armor_exclusions>
@@ -8669,6 +8676,13 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- True Thief Armor -->
+	<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
+		<exclusion>
+			<text>LB_</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
 	</enchantment_armor_exclusions>
 
 	<similarity_exclusions_armor>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -3127,7 +3127,7 @@
 			</exclusion>
 		<!-- Sovereign Slayer Armor -->
 		<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
-			exclusion>
+			<exclusion>
 				<text>LB_</text>
 				<target>EDID</target>
 				<type>STARTSWITH</type>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -1064,6 +1064,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Draconic Bloodline -->
+		<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
+			<exclusion>
+				<text>LB_</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
 		</distribution_exclusions_spell>
 
 		<distribution_exclusions_book>
@@ -1671,6 +1678,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Draconic Bloodline -->
+		<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
+			<exclusion>
+				<text>LB_</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
 		</distribution_exclusions_book>
 
 		<distribution_exclusions_list>
@@ -3112,6 +3126,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Sovereign Slayer Armor -->
+		<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
+			exclusion>
+				<text>LB_</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
 		</distribution_exclusions_weapon_regular>
 
 		<distribution_exclusions_list_regular>
@@ -4261,6 +4282,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Skyrim Sewers 4 -->
+		<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
+			<exclusion>
+				<text>LB_</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
 		</distribution_exclusions_weapon_enchanted>
 
 		<distribution_exclusions_list_enchanted>
@@ -5879,6 +5907,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- True Thief Armor -->
+		<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
+			<exclusion>
+				<text>LB_</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
 		</distribution_exclusions_armor_regular>
 
 		<distribution_exclusions_list_regular>
@@ -7296,6 +7331,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Wind Destruction -->
+		<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
+			<exclusion>
+				<text>LB_</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
 		</distribution_exclusions_armor_enchanted>
 
 		<distribution_exclusions_list_enchanted>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -2464,6 +2464,10 @@
 			<identifier>ForswornHigh</identifier>
 			<substring>Briarheart Geis</substring>
 		</binding>
+		<binding>
+			<identifier>Ancient Falmer</identifier>
+			<substring>Ancient Falmer</substring>
+		</binding>
 	<!-- Falmer/Forsworn bindings end -->
 
 	<!-- Giant Weapon bindings start -->

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -4350,6 +4350,14 @@
 			<reachModifier>-0.08</reachModifier>
 			<speedModifier>-0.1</speedModifier>
 		</weapon_material>
+		<weapon_material>
+			<damageModifier>1.6</damageModifier> <!-- 1.44 after Ancient binding-->
+			<identifier>Ancient Falmer</identifier>
+			<materialMeltdown>ELVEN</materialMeltdown>
+			<materialTemper>ELVEN</materialTemper>
+			<reachModifier>0.00</reachModifier>
+			<speedModifier>-0.03</speedModifier>
+		</weapon_material>
 	<!-- Falmer Material Listings end -->
 
 	<!-- Forsworn Material Listings start -->
@@ -5319,6 +5327,10 @@
 			<substring>Loner's Sword</substring>
 			<identifier>Arming Sword</identifier>
 		</binding>
+		<binding>
+			<substring>WinterStorm</substring>
+			<identifier>Arming Sword</identifier>
+		</binding>
 	<!-- Arming Sword bindings end -->
 
 	<!-- Broadsword bindings start -->
@@ -5577,6 +5589,10 @@
 		</binding>
 		<binding>
 			<substring>Elven Short Blade</substring>
+			<identifier>Dagger</identifier>
+		</binding>
+		<binding>
+			<substring>HoarFrost</substring>
 			<identifier>Dagger</identifier>
 		</binding>
 	<!-- Dagger bindings end -->
@@ -6792,6 +6808,14 @@
 			<substring>Great Club</substring>
 			<identifier>Longmace</identifier>
 		</binding>
+		<binding>
+			<substring>Warmace</substring>
+			<identifier>Longmace</identifier>
+		</binding>
+		<binding>
+			<substring>Black Ice</substring>
+			<identifier>Longmace</identifier>
+		</binding>
 	<!-- Longmace bindings end -->
 	
 	<!-- Nodachi bindings start -->
@@ -7208,6 +7232,14 @@
 		</binding>
 		<binding>
 			<substring>Dwemer Recurve Bow</substring>
+			<identifier>Longbow</identifier>
+		</binding>
+		<binding>
+			<substring>Ancient Falmer Bow</substring>
+			<identifier>Longbow</identifier>
+		</binding>
+		<binding>
+			<substring>Snowfall</substring>
 			<identifier>Longbow</identifier>
 		</binding>
 	<!-- Longbow bindings end -->
@@ -8597,6 +8629,38 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Knight of Thorns Armor and Spear of Thorns -->
+	<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
+		<exclusion>
+			<text>Moth's</text>
+			<target>NAME</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+		<exclusion>
+			<text>ZZZ</text>
+			<target>NAME</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+		<exclusion>
+			<text>Snowfall</text>
+			<target>NAME</target>
+			<type>EQUALS</type>
+		</exclusion>
+		<exclusion>
+			<text>WinterStorm</text>
+			<target>NAME</target>
+			<type>EQUALS</type>
+		</exclusion>
+		<exclusion>
+			<text>Black Ice</text>
+			<target>NAME</target>
+			<type>EQUALS</type>
+		</exclusion>
+		<exclusion>
+			<text>HoarFrost</text>
+			<target>NAME</target>
+			<type>EQUALS</type>
+		</exclusion>
+	<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
 	</reforge_exclusions>
 
 </ns2:weapons>


### PR DESCRIPTION
Removed Jalamark binding 

Added Ancient Falmer -> Gave it material/reach/speed bindings similar to Elven Put the damage at GlassLow(1.6x0.9[ancient)=1.44 GlassLow =1.45, as the original armor set had glass stats but I wanted to reflect the Ancient portion. GlassLow is also the averaged damage of Elven and Ebony Weaponry, which the wiki says the armor is a blend of. If you want to change the damage to match elvenhigh the new value should be 1.4 as 1.4x0.9 = 1.26 and ElvenHigh is 1.25.

Added a Longmace binding for Much ado's Warmace

There is another HoarFrost that is an Iron waraxe, but it is spelled Hoarfrost

Ammunition is Glass -1damage with elven speed and gravity
