### PR TITLE
Added The Hanging Gardens and It Beats For Her

### DIFF
--- a/SkyProc Patchers/T3nd0_PatchusMaximus/Files/BlockList.txt
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/Files/BlockList.txt
@@ -26,6 +26,7 @@ HorseCloakCH.esp
 HorseCloak.esp
 iNeed.esp
 Ish's Respec Mod.esp
+ItBeatsForHer.esp
 JaxonzDiagnostics.esp
 kuerteeEatAndSleep.esp
 KWTelescope.esp

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
@@ -8812,5 +8812,17 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
+	<!-- The Hanging Gardens -->
+		<exclusion>
+			<text>Bhabhilon</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+		<exclusion>
+			<text>_bh</text>
+			<target>EDID</target>
+			<type>CONTAINS</type>
+			</exclusion>
+	<!-- The Hanging Gardens -->
 	</reforge_exclusions>
 </ns2:armor>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
@@ -7607,6 +7607,13 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Conan Hyborian Age -->
+	<!-- The Hanging Gardens -->
+		<exclusion>
+			<text>_bh</text>
+			<target>EDID</target>
+			<type>CONTAINS</type>
+		</exclusion>
+	<!-- The Hanging Gardens -->
 	</enchantment_weapon_exclusions>
 
 	<enchantment_armor_exclusions>
@@ -8720,6 +8727,18 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
+	<!-- The Hanging Gardens -->
+		<exclusion>
+			<text>Bhabhilon</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+		<exclusion>
+			<text>_bh</text>
+			<target>EDID</target>
+			<type>CONTAINS</type>
+		</exclusion>
+	<!-- The Hanging Gardens -->
 	</enchantment_armor_exclusions>
 
 	<similarity_exclusions_armor>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -1071,6 +1071,18 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
+		<!-- The Hanging Gardens -->
+			<exclusion>
+				<text>Bhabhilon</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+			<exclusion>
+				<text>_bh</text>
+				<target>EDID</target>
+				<type>CONTAINS</type>
+			</exclusion>
+		<!-- The Hanging Gardens -->
 		</distribution_exclusions_spell>
 
 		<distribution_exclusions_book>
@@ -1685,6 +1697,28 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
+		<!-- The Hanging Gardens -->
+			<exclusion>
+				<text>_bh</text>
+				<target>EDID</target>
+				<type>CONTAINS</type>
+			</exclusion>
+			<exclusion>
+				<text>BhaBhilon</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+			<exclusion>
+				<text>Bhabhilon</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+			<exclusion>
+				<text>bhabhilon</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- The Hanging Gardens -->
 		</distribution_exclusions_book>
 
 		<distribution_exclusions_list>
@@ -3172,6 +3206,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Breton Knight -->
+		<!-- The Hanging Gardens -->
+			<exclusion>
+				<text>_bh</text>
+				<target>EDID</target>
+				<type>CONTAINS</type>
+			</exclusion>
+		<!-- The Hanging Gardens -->
 		</distribution_exclusions_weapon_regular>
 
 		<distribution_exclusions_list_regular>
@@ -4360,6 +4401,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Conan Hyborian Age -->
+		<!-- The Hanging Gardens -->
+			<exclusion>
+				<text>_bh</text>
+				<target>EDID</target>
+				<type>CONTAINS</type>
+			</exclusion>
+		<!-- The Hanging Gardens -->
 		</distribution_exclusions_weapon_enchanted>
 
 		<distribution_exclusions_list_enchanted>
@@ -5992,6 +6040,18 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Breton Knight -->
+		<!-- The Hanging Gardens -->
+			<exclusion>
+				<text>Bhabhilon</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+			<exclusion>
+				<text>_bh</text>
+				<target>EDID</target>
+				<type>CONTAINS</type>
+			</exclusion>
+		<!-- The Hanging Gardens -->
 		</distribution_exclusions_armor_regular>
 
 		<distribution_exclusions_list_regular>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -1739,6 +1739,10 @@
 			<identifier>DwarvenHigh</identifier>
 			<substring>Blade of the Rourken</substring>
 		</binding>
+		<binding>
+			<identifier>Dwarven</identifier>
+			<substring>Staff of Automaton Mastery</substring>
+		</binding>
 	<!-- Dwarven bindings end -->
 	
 	<!-- Ebony bindings start -->
@@ -2645,6 +2649,10 @@
 		<binding>
 			<identifier>Glass</identifier>
 			<substring>Dragon Skin Compound Bow</substring>
+		</binding>
+		<binding>
+			<identifier>Glass</identifier>
+			<substring>Seadog Cutlass</substring>
 		</binding>
 	<!-- Glass bindings end -->
 	
@@ -7032,6 +7040,10 @@
 			<substring>Heavy spiked mace</substring>
 			<identifier>Warhammer</identifier>
 		</binding>
+		<binding>
+			<substring>Staff of Automaton Mastery</substring>
+			<identifier>Warhammer</identifier>
+		</binding>
 	<!-- Warhammer bindings end -->
 	<!-- Great Morning Star bindings start -->
 		<binding>
@@ -8673,6 +8685,13 @@
 			<type>EQUALS</type>
 		</exclusion>
 	<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
+	<!-- The Hanging Gardens -->
+		<exclusion>
+			<text>_bh</text>
+			<target>EDID</target>
+			<type>CONTAINS</type>
+		</exclusion>
+	<!-- The Hanging Gardens -->
 	</reforge_exclusions>
 
 </ns2:weapons>


### PR DESCRIPTION
Uses Assets from Trainwiz's Mods and Hothtrooper's standalone Seadog armor
The Seadog Cutlass does not have a tempering recipe, so may have problems with mods like Loot and Degredation.
Hothtrooper's seadog has Glass stats in it's original form, which is why I assume the author gave the Weapon Glass Material
It beats For Her only needed exclusion bindings, so I put it on the blocklist
