### PR TITLE
Moon and Star, Sabres and Scimitars

### DIFF
--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
@@ -2966,6 +2966,10 @@
 			<identifier>EbonyLight</identifier>
 			<substring>Ebony Silver Mail</substring>
 		</binding>
+		<binding>
+			<identifier>Ebony</identifier>
+			<substring>Nerevarine</substring>
+		</binding>
 	<!-- Ebony Material Bindings end -->
 	
 	<!-- Elven Material Bindings start -->
@@ -5361,6 +5365,10 @@
 		<binding>
 			<identifier>Orcish</identifier>
 			<substring>Shield of Doom</substring>
+		</binding>
+		<binding>
+			<identifier>Orcish</identifier>
+			<substring>Bandit Leader's Helm</substring>
 		</binding>
 	<!-- Orcish Material Bindings end -->
 	
@@ -8824,5 +8832,12 @@
 			<type>CONTAINS</type>
 			</exclusion>
 	<!-- The Hanging Gardens -->
+	<!-- Moon and Star -->
+		<exclusion>
+			<text>MAS</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Moon and Star -->
 	</reforge_exclusions>
 </ns2:armor>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
@@ -7614,6 +7614,13 @@
 			<type>CONTAINS</type>
 		</exclusion>
 	<!-- The Hanging Gardens -->
+	<!-- Moon and Star -->
+		<exclusion>
+			<text>MAS</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type></type>
+		</exclusion>
+	<!-- Moon and Star -->
 	</enchantment_weapon_exclusions>
 
 	<enchantment_armor_exclusions>
@@ -8739,6 +8746,13 @@
 			<type>CONTAINS</type>
 		</exclusion>
 	<!-- The Hanging Gardens -->
+	<!-- Moon and Star -->
+		<exclusion>
+			<text>MAS</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Moon and Star -->
 	</enchantment_armor_exclusions>
 
 	<similarity_exclusions_armor>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -1083,6 +1083,18 @@
 				<type>CONTAINS</type>
 			</exclusion>
 		<!-- The Hanging Gardens -->
+		<!-- Moon and Star -->
+			<exclusion>
+				<text>MAS</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+			<exclusion>
+				<text>AbShieldMassCastBodyFXDUPLICATE001</text>
+				<target>EDID</target>
+				<type>EQUALS</type>
+			</exclusion>
+		<!-- Moon and Star -->
 		</distribution_exclusions_spell>
 
 		<distribution_exclusions_book>
@@ -1719,6 +1731,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- The Hanging Gardens -->
+		<!-- Moon and Star -->
+			<exclusion>
+				<text>MAS</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Moon and Star -->
 		</distribution_exclusions_book>
 
 		<distribution_exclusions_list>
@@ -3213,6 +3232,13 @@
 				<type>CONTAINS</type>
 			</exclusion>
 		<!-- The Hanging Gardens -->
+		<!-- Moon and Star -->
+			<exclusion>
+				<text>MAS</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Moon and Star -->
 		</distribution_exclusions_weapon_regular>
 
 		<distribution_exclusions_list_regular>
@@ -4408,6 +4434,13 @@
 				<type>CONTAINS</type>
 			</exclusion>
 		<!-- The Hanging Gardens -->
+		<!-- Moon and Star -->
+			<exclusion>
+				<text>MAS</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Moon and Star -->
 		</distribution_exclusions_weapon_enchanted>
 
 		<distribution_exclusions_list_enchanted>
@@ -6052,6 +6085,13 @@
 				<type>CONTAINS</type>
 			</exclusion>
 		<!-- The Hanging Gardens -->
+		<!-- Moon and Star -->
+			<exclusion>
+				<text>MAS</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Moon and Star -->
 		</distribution_exclusions_armor_regular>
 
 		<distribution_exclusions_list_regular>
@@ -7476,6 +7516,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Much Ado about Snow Elves – A Tragedy! Act I -->
+		<!-- Moon and Star -->
+			<exclusion>
+				<text>MAS</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Moon and Star -->
 		</distribution_exclusions_armor_enchanted>
 
 		<distribution_exclusions_list_enchanted>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -929,6 +929,10 @@
 			<identifier>BoundLow</identifier>
 			<substring>Divine Hammer</substring>
 		</binding>
+		<binding>
+			<identifier>BoundLow</identifier>
+			<substring>Bow of Shadows</substring>
+		</binding>
 	<!-- Bound Weapon bindings end -->
 
 	<!-- Chitin bindings start -->
@@ -1145,10 +1149,6 @@
 		</binding>
 		<binding>
 			<identifier>Daedric</identifier>
-			<substring>Hopesfire</substring>
-		</binding>
-		<binding>
-			<identifier>Daedric</identifier>
 			<substring>Cyrus' Saber</substring>
 		</binding>
 		<binding>
@@ -1250,6 +1250,10 @@
 		<binding>
 			<identifier>Daedric</identifier>
 			<substring>Sovereign's Slayer</substring>
+		</binding>
+		<binding>
+			<identifier>Daedric</identifier>
+			<substring>Black Hands Dagger</substring>
 		</binding>
 	<!-- Daedric bindings end -->
 	
@@ -1725,10 +1729,6 @@
 		</binding>
 		<binding>
 			<identifier>Dwarven</identifier>
-			<substring>Trueflame</substring>
-		</binding>
-		<binding>
-			<identifier>Dwarven</identifier>
 			<substring>Metal Compound Bow</substring>
 		</binding>
 		<binding>
@@ -1742,6 +1742,10 @@
 		<binding>
 			<identifier>Dwarven</identifier>
 			<substring>Staff of Automaton Mastery</substring>
+		</binding>
+		<binding>
+			<identifier>Dwarven</identifier>
+			<substring>Dorana's Hammer</substring>
 		</binding>
 	<!-- Dwarven bindings end -->
 	
@@ -2205,6 +2209,14 @@
 		<binding>
 			<identifier>EbonyHigh</identifier>
 			<substring>Spear of Thorns</substring>
+		</binding>
+		<binding>
+			<identifier>EbonyHigh</identifier>
+			<substring>Hopesfire</substring>
+		</binding>
+		<binding>
+			<identifier>EbonyHigh</identifier>
+			<substring>Trueflame</substring>
 		</binding>
 	<!-- Ebony bindings end -->
 	
@@ -3150,6 +3162,10 @@
 			<identifier>Stalhrim</identifier>
 			<substring>Darkshade Blade</substring>
 		</binding>
+		<binding>
+			<identifier>Stalhrim</identifier>
+			<substring>Mace of Aevar Stone-Singer</substring>
+		</binding>
 	<!-- Stalhrim bindings end -->
 	
 	<!-- Steel bindings start -->
@@ -3975,6 +3991,10 @@
 		<binding>
 			<identifier>Steelwood</identifier>
 			<substring>Colovian Dark Composite Bow</substring>
+		</binding>
+		<binding>
+			<identifier>Steelwood</identifier>
+			<substring>Ashlander's Bow</substring>
 		</binding>
 	<!-- Wood bindings end -->
 	</weapon_material_bindings>
@@ -5224,10 +5244,6 @@
 			<identifier>Arming Sword</identifier>
 		</binding>
 		<binding>
-			<substring>Hopesfire</substring>
-			<identifier>Arming Sword</identifier>
-		</binding>
-		<binding>
 			<substring>Bloodsbane</substring>
 			<identifier>Arming Sword</identifier>
 		</binding>
@@ -5308,10 +5324,6 @@
 			<identifier>Arming Sword</identifier>
 		</binding>
 		<binding>
-			<substring>Trueflame</substring>
-			<identifier>Arming Sword</identifier>
-		</binding>
-		<binding>
 			<substring>Windhelm sword</substring>
 			<identifier>Arming Sword</identifier>
 		</binding>
@@ -5356,6 +5368,18 @@
 	<!-- Broadsword bindings start -->
 		<binding>
 			<substring>Falchion</substring>
+			<identifier>Broadsword</identifier>
+		</binding>
+		<binding>
+			<substring>Genesis' Rapier</substring>
+			<identifier>Broadsword</identifier>
+		</binding>
+		<binding>
+			<substring>Baskethilt</substring>
+			<identifier>Broadsword</identifier>
+		</binding>
+		<binding>
+			<substring>Shiavonna</substring>
 			<identifier>Broadsword</identifier>
 		</binding>
 	<!-- Broadsword bindings end -->
@@ -5953,6 +5977,9 @@
 			<substring>Mace of Molag Bal</substring>
 			<identifier>Spiked Mace</identifier>
 		</binding>
+		<binding>
+			<substring></substring>
+		</binding>
 	<!-- Mace bindings end -->
 
 	<!-- Maul bindings start -->
@@ -5987,10 +6014,6 @@
 			<identifier>Sabre</identifier>
 		</binding>
 		<binding>
-			<substring>Genesis' Rapier</substring>
-			<identifier>Sabre</identifier>
-		</binding>
-		<binding>
 			<substring>Cutlass</substring>
 			<identifier>Sabre</identifier>
 		</binding>
@@ -5998,13 +6021,13 @@
 			<substring>Corsair's Sword</substring>
 			<identifier>Sabre</identifier>
 		</binding>
+		<binding>
+			<substring>Hopesfire</substring>
+			<identifier>Sabre</identifier>
+		</binding>
 	<!-- Sabre bindings end -->
 
 	<!-- Scimitar bindings start -->
-		<binding>
-			<substring>Baskethilt</substring>
-			<identifier>Scimitar</identifier>
-		</binding>
 		<binding>
 			<substring>Dremora Badelaire</substring>
 			<identifier>Scimitar</identifier>
@@ -6042,10 +6065,6 @@
 			<identifier>Scimitar</identifier>
 		</binding>
 		<binding>
-			<substring>Shiavonna</substring>
-			<identifier>Scimitar</identifier>
-		</binding>
-		<binding>
 			<substring>The Eagle Sword</substring>
 			<identifier>Scimitar</identifier>
 		</binding>
@@ -6079,6 +6098,10 @@
 		</binding>
 		<binding>
 			<substring>Rysh</substring>
+			<identifier>Scimitar</identifier>
+		</binding>
+		<binding>
+			<substring>Trueflame</substring>
 			<identifier>Scimitar</identifier>
 		</binding>
 	<!-- Scimitar bindings end -->
@@ -7044,6 +7067,10 @@
 			<substring>Staff of Automaton Mastery</substring>
 			<identifier>Warhammer</identifier>
 		</binding>
+		<binding>
+			<substring>Dorana's Hammer</substring>
+			<identifier>Warhammer</identifier>
+		</binding>
 	<!-- Warhammer bindings end -->
 	<!-- Great Morning Star bindings start -->
 		<binding>
@@ -7676,8 +7703,8 @@
 			<identifier>Sabre</identifier>
 			<baseWeaponType>SABRE</baseWeaponType>
 			<damageBase>11.0</damageBase>
-			<reachBase>0.85</reachBase>
-			<speedBase>0.85</speedBase>
+			<reachBase>0.9</reachBase>
+			<speedBase>1.05</speedBase>
 			<critDamageFactor>1.0</critDamageFactor>
 			<meltdownOutput>1</meltdownOutput>
 			<meltdownInput>1</meltdownInput>
@@ -7690,7 +7717,7 @@
 			<identifier>Scimitar</identifier>
 			<baseWeaponType>SCIMITAR</baseWeaponType>
 			<damageBase>12.0</damageBase>
-			<reachBase>0.95</reachBase>
+			<reachBase>1.0</reachBase>
 			<speedBase>0.95</speedBase>
 			<critDamageFactor>1.0</critDamageFactor>
 			<meltdownOutput>1</meltdownOutput>
@@ -8692,6 +8719,13 @@
 			<type>CONTAINS</type>
 		</exclusion>
 	<!-- The Hanging Gardens -->
+	<!-- Moon and Star -->
+		<exclusion>
+			<text>MAS</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Moon and Star -->
 	</reforge_exclusions>
 
 </ns2:weapons>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -5977,9 +5977,6 @@
 			<substring>Mace of Molag Bal</substring>
 			<identifier>Spiked Mace</identifier>
 		</binding>
-		<binding>
-			<substring></substring>
-		</binding>
 	<!-- Mace bindings end -->
 
 	<!-- Maul bindings start -->


### PR DESCRIPTION
Left Chrysamere alone, as there is no adamantium binding, and every mod and all of their mod's friends have it listed as Daedric.

Rebalanced scimitars and sabres. Saber's can be regarded as Scimitars as far as wikipedia is concerned, but I agree that it's better if they are defined separately for gameplay purposes. I divided them up like this, Sabres are: Thinner, shorter, or if nothing else, possess a blade that curves along it's whole length. Ie: cutlasses, cavalry sabres, and shamshir types. Scimitar's are: Thicker, Longer, or if nothing else, possess blades that curve at the end. Ie: tulwars, kilij

Moved baskethilted sword, Shiavonna, and Genesis' Rapier from scimitar and saber to broadsword as they are rapier hilted broadswords(edges on both sides) and do not curve in the slightest.

I specifically matched Trueflame to a Scimitar and Hopesfire to a sabre to reflect that in morrowind, Hopesfire did less damage per attack, had shorter reach, and swung faster than Trueflame. I know it's a kopesh, but there's no way to take advantage of a kopesh's shape in skyrim, so sabre works and saves bindings.

There was a duplicated Spell in the spells list:AbShieldMassCastBodyFXDUPLICATE001 I was wary of it, so I excluded it, if its not necessary let me know and I'll drop it from the LeveledList.xml. It didnt have a proper name in the Full-Name section either
