### PR TITLE
Osare Culort Armor -UNP

### DIFF
--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
@@ -1846,6 +1846,10 @@
 			<identifier>Daedric</identifier>
 			<substring>Sovereign's Slayer</substring>
 		</binding>
+		<binding>
+			<identifier>Daedric</identifier>
+			<substring>H8</substring>
+		</binding>
 	<!-- Daedric Material Bindings end -->
 	
 	<!-- Dragonplate Material Bindings start -->
@@ -2285,6 +2289,10 @@
 		<binding>
 			<identifier>Dragonscale_One</identifier>
 			<substring>Dragonbone Barbarian - Left</substring>
+		</binding>
+		<binding>
+			<identifier>Dragonscale</identifier>
+			<substring>L6</substring>
 		</binding>
 	<!-- Dragonscale Material Bindings end -->
 	
@@ -3834,6 +3842,10 @@
 			<identifier>Hide</identifier>
 			<substring>Pitfight</substring>
 		</binding>
+		<binding>
+			<identifier>Hide</identifier>
+			<substring>L1</substring>
+		</binding>
 	<!-- Hide Material Bindings end -->
 
 	<!-- Horker Material Bindings start -->
@@ -4189,6 +4201,10 @@
 		<binding>
 			<identifier>IronLight</identifier>
 			<substring>Ranger Shield</substring>
+		</binding>
+		<binding>
+			<identifier>Iron</identifier>
+			<substring>H1</substring>
 		</binding>
 	<!-- Iron Material Bindings end -->
 	
@@ -5370,6 +5386,10 @@
 			<identifier>Orcish</identifier>
 			<substring>Bandit Leader's Helm</substring>
 		</binding>
+		<binding>
+			<identifier>Orcish</identifier>
+			<substring>H5</substring>
+		</binding>
 	<!-- Orcish Material Bindings end -->
 	
 	<!-- Scaled Material Bindings start -->
@@ -5829,6 +5849,10 @@
 		<binding>
 			<identifier>ScaledHigh</identifier>
 			<substring>Riften Nightwatch</substring>
+		</binding>
+		<binding>
+			<identifier>Scaled</identifier>
+			<substring>L4</substring>
 		</binding>
 	<!-- Scaled Material Bindings end -->
 	

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
@@ -8753,6 +8753,13 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Moon and Star -->
+	<!-- Osare Culort Outfit - UNP -->
+		<exclusion>
+			<text>Culort</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Osare Culort Outfit - UNP -->
 	</enchantment_armor_exclusions>
 
 	<similarity_exclusions_armor>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -1095,6 +1095,13 @@
 				<type>EQUALS</type>
 			</exclusion>
 		<!-- Moon and Star -->
+		<!-- Osare Culort Outfit - UNP -->
+			<exclusion>
+				<text>Culort</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Osare Culort Outfit - UNP -->
 		</distribution_exclusions_spell>
 
 		<distribution_exclusions_book>
@@ -6092,6 +6099,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Moon and Star -->
+		<!-- Osare Culort Outfit - UNP -->
+			<exclusion>
+				<text>Culort</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Osare Culort Outfit - UNP -->
 		</distribution_exclusions_armor_regular>
 
 		<distribution_exclusions_list_regular>
@@ -7523,6 +7537,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Moon and Star -->
+		<!-- Osare Culort Outfit - UNP -->
+			<exclusion>
+				<text>Culort</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Osare Culort Outfit - UNP -->
 		</distribution_exclusions_armor_enchanted>
 
 		<distribution_exclusions_list_enchanted>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -3331,10 +3331,6 @@
 		</binding>
 		<binding>
 			<identifier>Steel</identifier>
-			<substring>Champion</substring>
-		</binding>
-		<binding>
-			<identifier>Steel</identifier>
 			<substring>Bronze</substring>
 		</binding>
 		<binding>


### PR DESCRIPTION
Flying lamp thing is cool, anyways,
Osare Culort armor has alternate materials for each armor piece, listed as: H1:Iron H5:Orcish H8:Daedric L1:Hide L4:Scaled L6:Dragonscale. I didnt see any conflicts with other mods despite the short bindings so in the interest of saving syntax I added them. It is something that could cause problems with similar listing patterns and I can remove it if you want and redo them with the full armor piece names.

Champion was bound to Steel twice in the weapons xml
