### PR TITLE
Companion Valfar and Sofia, Sulfurus

### DIFF
--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
@@ -4210,10 +4210,6 @@
 			<identifier>Iron</identifier>
 			<substring>H1</substring>
 		</binding>
-		<binding>
-			<identifier>IronHigh</identifier>
-			<substring>Valfar's Helmet</substring>
-		</binding>
 	<!-- Iron Material Bindings end -->
 	
 	<!-- Leather Material Bindings start -->

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
@@ -2074,6 +2074,10 @@
 			<identifier>Dragonplate</identifier>
 			<substring>Knight Thorns</substring>
 		</binding>
+		<binding>
+			<identifier>DragonplateHigh</identifier>
+			<substring>Valfar's Armor</substring>
+		</binding>
 	<!-- Dragonplate Material Bindings end -->
 	
 	<!-- Dragonscale Material Bindings start -->
@@ -4205,6 +4209,10 @@
 		<binding>
 			<identifier>Iron</identifier>
 			<substring>H1</substring>
+		</binding>
+		<binding>
+			<identifier>IronHigh</identifier>
+			<substring>Valfar's Helmet</substring>
 		</binding>
 	<!-- Iron Material Bindings end -->
 	
@@ -8863,5 +8871,12 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Moon and Star -->
+	<!-- Companion Valfar -->
+		<exclusion>
+			<text>OS_CV</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Companion Valfar -->
 	</reforge_exclusions>
 </ns2:armor>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
@@ -7621,6 +7621,13 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Moon and Star -->
+	<!-- Companion Valfar -->
+		<exclusion>
+			<text>OS_CV</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Companion Valfar -->
 	</enchantment_weapon_exclusions>
 
 	<enchantment_armor_exclusions>
@@ -8760,6 +8767,13 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Osare Culort Outfit - UNP -->
+	<!-- Companion Valfar -->
+		<exclusion>
+			<text>OS_CV</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Companion Valfar -->
 	</enchantment_armor_exclusions>
 
 	<similarity_exclusions_armor>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -1102,6 +1102,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Osare Culort Outfit - UNP -->
+		<!-- Sofia - The Funny Fully Voiced Follower -->
+			<exclusion>
+				<text>Sofia</text>
+				<target>EDID</target>
+				<type>CONTAINS</type>
+			</exclusion>
+		<!-- Sofia - The Funny Fully Voiced Follower -->
 		</distribution_exclusions_spell>
 
 		<distribution_exclusions_book>
@@ -3246,6 +3253,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Moon and Star -->
+		<!-- Companion Valfar -->
+			<exclusion>
+				<text>OS_CV</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Companion Valfar -->
 		</distribution_exclusions_weapon_regular>
 
 		<distribution_exclusions_list_regular>
@@ -6106,6 +6120,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Osare Culort Outfit - UNP -->
+		<!-- Companion Valfar -->
+			<exclusion>
+				<text>OS_CV</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Companion Valfar -->
 		</distribution_exclusions_armor_regular>
 
 		<distribution_exclusions_list_regular>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -1752,6 +1752,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Moon and Star -->
+		<!-- Sulfuras - The Reclaimed Hand -->
+			<exclusion>
+				<text>Sulfuras</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Sulfuras - The Reclaimed Hand -->
 		</distribution_exclusions_book>
 
 		<distribution_exclusions_list>
@@ -4462,6 +4469,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Moon and Star -->
+		<!-- Sulfuras - The Reclaimed Hand -->
+			<exclusion>
+				<text>Sulfuras</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Sulfuras - The Reclaimed Hand -->
 		</distribution_exclusions_weapon_enchanted>
 
 		<distribution_exclusions_list_enchanted>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -7072,6 +7072,10 @@
 			<substring>Dorana's Hammer</substring>
 			<identifier>Warhammer</identifier>
 		</binding>
+		<binding>
+			<substring>Sulfuras</substring>
+			<identifier>Warhammer</identifier>
+		</binding>
 	<!-- Warhammer bindings end -->
 	<!-- Great Morning Star bindings start -->
 		<binding>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -1255,6 +1255,10 @@
 			<identifier>Daedric</identifier>
 			<substring>Black Hands Dagger</substring>
 		</binding>
+		<binding>
+			<identifier>DaedricHigh</identifier>
+			<substring>Sulfuras</substring>
+		</binding>
 	<!-- Daedric bindings end -->
 	
 	<!-- Dragonplate bindings start -->
@@ -8730,6 +8734,13 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Companion Valfar -->
+	<!-- Sulfuras - The Reclaimed Hand -->
+		<exclusion>
+			<text>Sulfuras</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Sulfuras - The Reclaimed Hand -->
 	</reforge_exclusions>
 
 </ns2:weapons>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -2848,6 +2848,10 @@
 			<identifier>Iron</identifier>
 			<substring>Wood Compound Bow</substring>
 		</binding>
+		<binding>
+			<identifier>Iron</identifier>
+			<substring>Valfar's Battleaxe</substring>
+		</binding>
 	<!-- Iron bindings end -->
 	
 	<!-- Iron/Wood Clutter bindings start -->
@@ -8719,6 +8723,13 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Moon and Star -->
+	<!-- Companion Valfar -->
+		<exclusion>
+			<text>OS_CV</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Companion Valfar -->
 	</reforge_exclusions>
 
 </ns2:weapons>


### PR DESCRIPTION
Issue #38 Valfar
Issue #42 Sofia
Issue #359 Sulfuras -The Reclaimed Hand
Valfar's Helmet does not have a proper helmet binding, and wont patch
Valfar's Armor is only labeled as a Curiass, but it also includes his Gloves and Boots 
Vlfar's Banner Has no armor rating and is not patched
Valfars Battleaxe is an Iron battleaxe and should do Iron Battleaxe damage, so I patched it to that, despite it having Daedric Stats
All of Valfar's Items are Non-Playable and lack tempering recipes
The follower Sofia only appears to need spell exclusions
Sulfuras only adds an enchanted weapon, So it shouldn't need an enchantment exclusion.

I apologize for that MAS typo, I'll check that portion better in the future.
