### PR TITLE
Rigmor, Grey Cowl of Nocturnal, Armor of Intrigue

### DIFF
--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Ammunition.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Ammunition.xml
@@ -977,6 +977,12 @@
 			<substring>Breton Knighl</substring> <!-- how it actually appears in the esp -->
 		</binding>
 	<!-- Breton Knight -->
+	<!-- The Grey Cowl of Nocturnal -->
+		<binding>
+			<identifier>Steel</identifier>
+			<substring>Arrow of Extrication</substring>
+		</binding>
+	<!-- The Grey Cowl of Nocturnal -->
 	</ammunition_material_bindings>
 
 	<ammunition_exclusions_multiplication>
@@ -1072,6 +1078,13 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- SkyRe Races -->
+	<!-- The Grey Cowl of Nocturnal -->
+		<exclusion>
+			<text>manny_GF_Ammo_ExtricationArrow</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- The Grey Cowl of Nocturnal -->
 	</ammunition_exclusions_multiplication>
 
 	</ns2:ammunition>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Ammunition.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Ammunition.xml
@@ -983,6 +983,12 @@
 			<substring>Arrow of Extrication</substring>
 		</binding>
 	<!-- The Grey Cowl of Nocturnal -->
+	<!-- Rigmor of Bruma -->
+		<binding>
+			<identifier>Iron</identifier>
+			<substring>Long Bow Arrow</substring>
+		</binding>
+	<!-- Rigmor of Bruma -->
 	</ammunition_material_bindings>
 
 	<ammunition_exclusions_multiplication>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
@@ -6342,6 +6342,10 @@
 			<identifier>SteelLight</identifier>
 			<substring>Plate scarf</substring><!-- Zzjays Wardrobe the lower case word is correct -->
 		</binding>
+		<binding>
+			<identifier>Steel</identifier>
+			<substring>Rigmors</substring>
+		</binding>
 	<!-- Steel Material Bindings end -->
 	
 	<!-- Steel Plate Material Bindings start -->
@@ -8903,5 +8907,12 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- The Grey Cowl of Nocturnal -->
+	<!-- Rigmor of Bruma-->
+		<exclusion>
+			<text>Rigmor_Armor</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Rigmor of Bruma -->
 	</reforge_exclusions>
 </ns2:armor>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
@@ -4218,6 +4218,10 @@
 			<identifier>Iron</identifier>
 			<substring>Yokuda</substring>
 		</binding>
+		<binding>
+			<identifier>IronHigh</identifier>
+			<substring>Rigmors Cuirass</substring>
+		</binding>
 	<!-- Iron Material Bindings end -->
 	
 	<!-- Leather Material Bindings start -->
@@ -5045,6 +5049,10 @@
 		<binding>
 			<identifier>LeatherHigh</identifier>
 			<substring>ArmorOfIntrigue</substring>
+		</binding>
+		<binding>
+			<identifier>LeatherHeavy</identifier>
+			<substring>Rigmors Boots</substring>
 		</binding>
 	<!-- Leather Material Bindings end -->
 	
@@ -6344,7 +6352,7 @@
 		</binding>
 		<binding>
 			<identifier>Steel</identifier>
-			<substring>Rigmors</substring>
+			<substring>Rigmors Gauntlets</substring>
 		</binding>
 	<!-- Steel Material Bindings end -->
 	

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
@@ -8909,7 +8909,7 @@
 	<!-- The Grey Cowl of Nocturnal -->
 	<!-- Rigmor of Bruma-->
 		<exclusion>
-			<text>Rigmor_Armor</text>
+			<text>Rigmor_</text>
 			<target>EDID</target>
 			<type>STARTSWITH</type>
 		</exclusion>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
@@ -3850,6 +3850,10 @@
 			<identifier>Hide</identifier>
 			<substring>L1</substring>
 		</binding>
+		<binding>
+			<identifier>Hide</identifier>
+			<substring>Gray Cowl Of Nocturnal</substring>
+		</binding>
 	<!-- Hide Material Bindings end -->
 
 	<!-- Horker Material Bindings start -->
@@ -4209,6 +4213,10 @@
 		<binding>
 			<identifier>Iron</identifier>
 			<substring>H1</substring>
+		</binding>
+		<binding>
+			<identifier>Iron</identifier>
+			<substring>Yokuda</substring>
 		</binding>
 	<!-- Iron Material Bindings end -->
 	
@@ -8874,5 +8882,22 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Companion Valfar -->
+	<!-- The Grey Cowl of Nocturnal -->
+		<exclusion>
+			<text>manny_GF_Armor_GrayCowl</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+		<exclusion>
+			<text>manny_GF_Armor_BootsofSpringheelJak</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+		<exclusion>
+			<text>manny_GF_Armor_Yokuda</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- The Grey Cowl of Nocturnal -->
 	</reforge_exclusions>
 </ns2:armor>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
@@ -5042,6 +5042,10 @@
 			<identifier>Leather</identifier>
 			<substring>Thief</substring>
 		</binding>
+		<binding>
+			<identifier>LeatherHigh</identifier>
+			<substring>ArmorOfIntrigue</substring>
+		</binding>
 	<!-- Leather Material Bindings end -->
 	
 	<!-- None Material Listings start -->

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
@@ -7635,6 +7635,18 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- The Grey Cowl of Nocturnal -->
+	<!-- Rigmor of Bruma -->
+		<exclusion>
+			<text>Rigmor_</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+		<exclusion>
+			<text>CasiusVaron</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Rigmor of Bruma -->
 	</enchantment_weapon_exclusions>
 
 	<enchantment_armor_exclusions>
@@ -8805,6 +8817,13 @@
 			<type>CONTAINS</type>
 		</exclusion>
 	<!-- Armor Of Intrigue -->
+	<!-- Rigmor of Bruma -->
+		<exclusion>
+			<text>Rigmor_</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Rigmor of Bruma -->
 	</enchantment_armor_exclusions>
 
 	<similarity_exclusions_armor>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
@@ -8798,6 +8798,13 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- The Grey Cowl of Nocturnal -->
+	<!-- Armor Of Intrigue -->
+		<exclusion>
+			<text>ArmorOfIntrigue</text>
+			<target>EDID</target>
+			<type>CONTAINS</type>
+		</exclusion>
+	<!-- Armor Of Intrigue -->
 	</enchantment_armor_exclusions>
 
 	<similarity_exclusions_armor>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
@@ -7628,6 +7628,13 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Companion Valfar -->
+	<!-- The Grey Cowl of Nocturnal -->
+		<exclusion>
+			<text>manny_GF_Weapon</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- The Grey Cowl of Nocturnal -->
 	</enchantment_weapon_exclusions>
 
 	<enchantment_armor_exclusions>
@@ -8774,6 +8781,23 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Companion Valfar -->
+	<!-- The Grey Cowl of Nocturnal -->
+		<exclusion>
+			<text>manny_GF_Armor_GrayCowl</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+		<exclusion>
+			<text>manny_GF_Armor_BootsofSpringheelJak</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+		<exclusion>
+			<text>manny_GF_Armor_Yokuda</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- The Grey Cowl of Nocturnal -->
 	</enchantment_armor_exclusions>
 
 	<similarity_exclusions_armor>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -1116,6 +1116,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- The Grey Cowl of Nocturnal -->
+		<!-- Rigmor of Bruma -->
+			<exclusion>
+				<text>Rigmor_</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Rigmor of Bruma -->
 		</distribution_exclusions_spell>
 
 		<distribution_exclusions_book>
@@ -1773,6 +1780,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- The Grey Cowl of Nocturnal -->
+		<!-- Rigmor of Bruma -->
+			<exclusion>
+				<text>Rigmor</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Rigmor of Bruma -->
 		</distribution_exclusions_book>
 
 		<distribution_exclusions_list>
@@ -3288,6 +3302,18 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- The Grey Cowl of Nocturnal -->
+		<!-- Rigmor of Bruma -->
+			<exclusion>
+				<text>Rigmor_</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+			<exclusion>
+				<text>CasiusVaron</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Rigmor of Bruma -->
 		</distribution_exclusions_weapon_regular>
 
 		<distribution_exclusions_list_regular>
@@ -4504,6 +4530,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- The Grey Cowl of Nocturnal -->
+		<!-- Rigmor of Bruma -->
+			<exclusion>
+				<text>Rigmor_</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Rigmor of Bruma -->
 		</distribution_exclusions_weapon_enchanted>
 
 		<distribution_exclusions_list_enchanted>
@@ -6183,6 +6216,13 @@
 				<type>CONTAINS</type>
 			</exclusion>
 		<!-- Armor Of Intrigue -->
+		<!-- Rigmor of Bruma -->
+			<exclusion>
+				<text>Rigmor_</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Rigmor of Bruma -->
 		</distribution_exclusions_armor_regular>
 
 		<distribution_exclusions_list_regular>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -1109,6 +1109,13 @@
 				<type>CONTAINS</type>
 			</exclusion>
 		<!-- Sofia - The Funny Fully Voiced Follower -->
+		<!-- The Grey Cowl of Nocturnal -->
+			<exclusion>
+				<text>manny_GF_</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- The Grey Cowl of Nocturnal -->
 		</distribution_exclusions_spell>
 
 		<distribution_exclusions_book>
@@ -1759,6 +1766,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Sulfuras - The Reclaimed Hand -->
+		<!-- The Grey Cowl of Nocturnal -->
+			<exclusion>
+				<text>manny_GF_</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- The Grey Cowl of Nocturnal -->
 		</distribution_exclusions_book>
 
 		<distribution_exclusions_list>
@@ -3267,6 +3281,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Companion Valfar -->
+		<!-- The Grey Cowl of Nocturnal -->
+			<exclusion>
+				<text>manny_GF_Weapon</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- The Grey Cowl of Nocturnal -->
 		</distribution_exclusions_weapon_regular>
 
 		<distribution_exclusions_list_regular>
@@ -4476,6 +4497,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Sulfuras - The Reclaimed Hand -->
+		<!-- The Grey Cowl of Nocturnal -->
+			<exclusion>
+				<text>manny_GF_Weapon</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- The Grey Cowl of Nocturnal -->
 		</distribution_exclusions_weapon_enchanted>
 
 		<distribution_exclusions_list_enchanted>
@@ -6141,6 +6169,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Companion Valfar -->
+		<!-- The Grey Cowl of Nocturnal -->
+			<exclusion>
+				<text>manny_GF_</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- The Grey Cowl of Nocturnal -->
 		</distribution_exclusions_armor_regular>
 
 		<distribution_exclusions_list_regular>
@@ -7579,6 +7614,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Osare Culort Outfit - UNP -->
+		<!-- The Grey Cowl of Nocturnal -->
+			<exclusion>
+				<text>manny_GF_</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- The Grey Cowl of Nocturnal -->
 		</distribution_exclusions_armor_enchanted>
 
 		<distribution_exclusions_list_enchanted>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -7675,6 +7675,13 @@
 				<type>CONTAINS</type>
 			</exclusion>
 		<!-- Armor Of Intrigue -->
+		<!-- Rigmor of Bruma -->
+			<exclusion>
+				<text>Rigmor_</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Rigmor of Bruma -->
 		</distribution_exclusions_armor_enchanted>
 
 		<distribution_exclusions_list_enchanted>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -6176,6 +6176,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- The Grey Cowl of Nocturnal -->
+		<!-- Armor Of Intrigue -->
+			<exclusion>
+				<text>ArmorOfIntrigue</text>
+				<target>EDID</target>
+				<type>CONTAINS</type>
+			</exclusion>
+		<!-- Armor Of Intrigue -->
 		</distribution_exclusions_armor_regular>
 
 		<distribution_exclusions_list_regular>
@@ -7621,6 +7628,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- The Grey Cowl of Nocturnal -->
+		<!-- Armor Of Intrigue -->
+			<exclusion>
+				<text>ArmorOfIntrigue</text>
+				<target>EDID</target>
+				<type>CONTAINS</type>
+			</exclusion>
+		<!-- Armor Of Intrigue -->
 		</distribution_exclusions_armor_enchanted>
 
 		<distribution_exclusions_list_enchanted>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -3809,6 +3809,14 @@
 			<identifier>Steel</identifier>
 			<substring>Loner's Greatword</substring>
 		</binding>
+		<binding>
+			<identifier>Steel</identifier>
+			<substring>Rigmors Bastard Sword</substring>
+		</binding>
+		<binding>
+			<identifier>Steel</identifier>
+			<substring>Replica Heirloom Sword</substring>
+		</binding>
 	<!-- Steel bindings end -->
 
 	<!-- Skyforge bindings start -->
@@ -6392,6 +6400,14 @@
 			<substring>Redguard slasher</substring>
 			<identifier>Bastard Sword</identifier>
 		</binding>
+		<binding>
+			<substring>Replica Heirloom Sword</substring>
+			<identifier>Bastard Sword</identifier>
+		</binding>
+		<binding>
+			<substring>Azuras Bane</substring>
+			<identifier>Bastard Sword</identifier>
+		</binding>
 	<!-- Bastard Sword bindings end -->
 	
 	<!-- Battleaxe bindings start -->
@@ -8771,6 +8787,18 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- The Grey Cowl of Nocturnal -->
+	<!-- Rigmor of Bruma -->
+		<exclusion>
+			<text>Rigmor_</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+		<exclusion>
+			<text>CasiusVaron</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- Rigmor of Bruma -->
 	</reforge_exclusions>
 
 </ns2:weapons>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -1544,6 +1544,10 @@
 			<identifier>Draugr</identifier>
 			<substring>Ash Spawn</substring>
 		</binding>
+		<binding>
+			<identifier>Draugr Honed</identifier>
+			<substring>Bow of the Forgotten Chaos</substring>
+		</binding>
 	<!-- Drauger bindings end -->
 	
 	<!-- Dwarven bindings start -->
@@ -2855,6 +2859,10 @@
 		<binding>
 			<identifier>Iron</identifier>
 			<substring>Valfar's Battleaxe</substring>
+		</binding>
+		<binding>
+			<identifier>Iron</identifier>
+			<substring>The Withdrawal</substring>
 		</binding>
 	<!-- Iron bindings end -->
 	
@@ -6106,7 +6114,14 @@
 			<identifier>Scimitar</identifier>
 		</binding>
 	<!-- Scimitar bindings end -->
-
+	
+	<!-- Shiv bindings start -->
+		<binding>
+			<substring>The Withdrawal</substring>
+			<identifier>Shiv</identifier>
+		</binding>
+	<!-- Shiv bindings end>
+	
 	<!-- Shortspear bindings start -->
 		<binding>
 			<substring>Pokeblade</substring>
@@ -7296,6 +7311,10 @@
 		</binding>
 		<binding>
 			<substring>Snowfall</substring>
+			<identifier>Longbow</identifier>
+		</binding>
+		<binding>
+			<substring>Bow of the Forgotten Chaos</substring>
 			<identifier>Longbow</identifier>
 		</binding>
 	<!-- Longbow bindings end -->
@@ -8745,6 +8764,13 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Sulfuras - The Reclaimed Hand -->
+	<!-- The Grey Cowl of Nocturnal -->
+		<exclusion>
+			<text>manny_GF_Weapon</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- The Grey Cowl of Nocturnal -->
 	</reforge_exclusions>
 
 </ns2:weapons>


### PR DESCRIPTION
Issue #360 
Issue #287 
Issue #197 

Grey Cowl of Nocturnal:
Left Umbra alone, as it had previous bindings.
All weapons added are enchanted or unplayable
The Withdrawel is an enchanted shiv, so I added it to the shiv category
I chose steel for the arrow of extrication based on the nif appearance, as there was no precedent in the esp.

Rigmor of Bruma:
TBH, I have no idea what the author was thinking when they made the material bindings for Rigmors armor, so I rebound it based on appearance.

Armor of Intrigue:
After trying to make my own patch for it, I found out that EnchFortifyLockpicking is actually a peak value modifier and I'm just blind apparently. 
