### PR TITLE
Immersive Weapons Fix.

### DIFF
--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -5391,6 +5391,10 @@
 			<substring>Breton Knight Sword</substring>
 			<identifier>Arming Sword</identifier>
 		</binding>
+		<binding>
+			<substring>Black Sting</substring>
+			<identifier>Arming Sword</identifier>
+		</binding>
 	<!-- Arming Sword bindings end -->
 
 	<!-- Broadsword bindings start -->
@@ -5608,7 +5612,7 @@
 			<identifier>Dagger</identifier>
 		</binding>
 		<binding>
-			<substring>Black Sting</substring>
+			<substring>Black Sting Dagger</substring>
 			<identifier>Dagger</identifier>
 		</binding>
 		<binding>
@@ -6881,6 +6885,10 @@
 +			<substring>G. Sword</substring>
 +			<identifier>Greatsword</identifier>
 +		</binding>
+		<binding>
+			<substring>Black Sting Greatsword</substring>
+			<identifier>Greatsword</identifier>
+		</binding>
 	<!-- Greatsword bindings end -->
 	
 	<!-- Halberd bindings start -->


### PR DESCRIPTION
Black sting is actually meant to be a one-handed sword with a dagger and a Greatsword version(named accordingly).

Also LWE/IW require a patch. Draedric Cresent is a One-hander in 'Immersive Weapons' but a greatsword in 'Lore Weapon Expansion',Unfortunately Greatsword bindings will always overwrite Arming Sword Bindings so either LWE needs a patch to add "Greatsword" or' IW needs a patch and there needs to be another binding section for binding overrides like this.
