### PR TITLE
InsanitySorrow's Zatoichi, Vayan Armor, Belko follower and VanNord Carved Nordic Armor Support.(Various fixes as well.)

### DIFF
--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Ammunition.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Ammunition.xml
@@ -1069,6 +1069,12 @@
 			<substring>Steam Arrows</substring>
 		</binding>
 	<!-- Elemental Arrows -->
+	<!-- VanNord -->
+		<binding>
+			<identifier>NordicNoMult</identifier>
+			<substring>VanNord</substring>
+		</binding>
+	<!-- VanNord -->
 	</ammunition_material_bindings>
 
 	<ammunition_exclusions_multiplication>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
@@ -5202,6 +5202,10 @@
 			<identifier>HNordic</identifier>
 			<substring>Feyngaar's Helmet</substring>
 		</binding>
+		<binding>
+			<identifier>HNordic</identifier>
+			<substring>VanNord</substring>
+		</binding>
 	<!-- Nord Material Bindings end -->
 	
 	<!-- Orcish Material Bindings start -->

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
@@ -3854,6 +3854,10 @@
 			<identifier>Hide</identifier>
 			<substring>Gray Cowl Of Nocturnal</substring>
 		</binding>
+		<binding>
+			<identifier>Hide</identifier>
+			<substring>Belko</substring>
+		</binding>
 	<!-- Hide Material Bindings end -->
 
 	<!-- Horker Material Bindings start -->
@@ -5877,6 +5881,10 @@
 		<binding>
 			<identifier>Scaled</identifier>
 			<substring>L4</substring>
+		</binding>
+		<binding>
+			<identifier>Scaled</identifier>
+			<substring>Vayan</substring>
 		</binding>
 	<!-- Scaled Material Bindings end -->
 	

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
@@ -5886,10 +5886,6 @@
 			<identifier>Scaled</identifier>
 			<substring>L4</substring>
 		</binding>
-		<binding>
-			<identifier>Scaled</identifier>
-			<substring>Vayan</substring>
-		</binding>
 	<!-- Scaled Material Bindings end -->
 	
 	<!-- Silver Material Bindings start -->
@@ -6721,6 +6717,10 @@
 		<binding>
 			<identifier>HStalhrim</identifier>
 			<substring>Red Stalhrim Heavy</substring>
+		</binding>
+		<binding>
+			<identifier>LStalhrimLow</identifier>
+			<substring>Vayan</substring>
 		</binding>
 	<!-- Stalhrim Material Bindings end -->
 	

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -3354,6 +3354,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- VanNord -->
+		<!-- Isilmeriel LOTR Weapons Collection -->
+			<exclusion>
+				<text>isil</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Isilmeriel LOTR Weapons Collection -->
 		</distribution_exclusions_weapon_regular>
 
 		<distribution_exclusions_list_regular>
@@ -4596,6 +4603,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- VanNord -->
+		<!-- Isilmeriel LOTR Weapons Collection -->
+			<exclusion>
+				<text>isil</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Isilmeriel LOTR Weapons Collection -->
 		</distribution_exclusions_weapon_enchanted>
 
 		<distribution_exclusions_list_enchanted>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -3342,6 +3342,18 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Campfire -->
+		<!-- VanNord -->
+			<exclusion>
+				<text>AnewVanNord</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+			<exclusion>
+				<text>AnewNordic</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- VanNord -->
 		</distribution_exclusions_weapon_regular>
 
 		<distribution_exclusions_list_regular>
@@ -4572,6 +4584,18 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Sword Of the Ancient Tongue -->
+		<!-- VanNord -->
+			<exclusion>
+				<text>AnewVanNord</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+			<exclusion>
+				<text>AnewNordic</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- VanNord -->
 		</distribution_exclusions_weapon_enchanted>
 
 		<distribution_exclusions_list_enchanted>
@@ -6279,6 +6303,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Belko Follower -->
+		<!-- VanNord -->
+			<exclusion>
+				<text>AnewArmorNordic</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- VanNord -->
 		</distribution_exclusions_armor_regular>
 
 		<distribution_exclusions_list_regular>
@@ -7752,6 +7783,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Belko Follower -->
+		<!-- VanNord -->
+			<exclusion>
+				<text>AnewArmorNordic</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- VanNord -->
 		</distribution_exclusions_armor_enchanted>
 
 		<distribution_exclusions_list_enchanted>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -6265,6 +6265,20 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Campfire -->
+		<!-- Vayan Armor -->
+			<exclusion>
+				<text>001Vayan</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Vayan Armor -->
+		<!-- Belko Follower -->
+			<exclusion>
+				<text>aaaBelko</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Belko Follower -->
 		</distribution_exclusions_armor_regular>
 
 		<distribution_exclusions_list_regular>
@@ -7724,6 +7738,20 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Rigmor of Bruma -->
+		<!-- Vayan Armor -->
+			<exclusion>
+				<text>001Vayan</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Vayan Armor -->
+		<!-- Belko Follower -->
+			<exclusion>
+				<text>aaaBelko</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Belko Follower -->
 		</distribution_exclusions_armor_enchanted>
 
 		<distribution_exclusions_list_enchanted>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -6575,6 +6575,10 @@
 			<substring>Hrothmund</substring>
 			<identifier>Battleaxe</identifier>
 		</binding>
+		<binding>
+			<substring>Battlexe</substring>
+			<identifier>Battleaxe</identifier>
+		</binding>
 	<!-- Battleaxe bindings end -->
 	
 	<!-- Battlestaff bindings start -->
@@ -7176,6 +7180,10 @@
 		</binding>
 		<binding>
 			<substring>Dwemer Automatic Projectile Launcher</substring>
+			<identifier>Crossbow</identifier>
+		</binding>
+		<binding>
+			<substring>Aetherial Bolt Launcher</substring>
 			<identifier>Crossbow</identifier>
 		</binding>
 	<!-- Crossbow bindings end -->

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -6810,10 +6810,6 @@
 			<identifier>Greatsword</identifier>
 		</binding>
 		<binding>
-			<substring>Daedric Crescent</substring>
-			<identifier>Greatsword</identifier>
-		</binding>
-		<binding>
 			<substring>Great Daedric Crescent</substring>
 			<identifier>Greatsword</identifier>
 		</binding>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -5752,6 +5752,10 @@
 			<substring>Cloud Courtblade</substring>
 			<identifier>Katana</identifier>
 		</binding>
+		<binding>
+			<substring>Zatoichi</substring>
+			<identifier>Katana</identifier>
+		</binding>
 	<!-- Katana bindings end -->
 
 	<!-- Knuckles bindings start -->
@@ -6263,6 +6267,30 @@
 		</binding>
 		<binding>
 			<substring>Akaviri Short Saber</substring>
+			<identifier>Tanto</identifier>
+		</binding>
+		<binding>
+			<substring>Short Steel Zatoichi</substring>
+			<identifier>Tanto</identifier>
+		</binding>
+		<binding>
+			<substring>Short Iron Zatoichi</substring>
+			<identifier>Tanto</identifier>
+		</binding>
+		<binding>
+			<substring>Short Ebony  Zatoichi</substring>
+			<identifier>Tanto</identifier>
+		</binding>
+		<binding>
+			<substring>Short Dwarven  Zatoichi</substring>
+			<identifier>Tanto</identifier>
+		</binding>
+		<binding>
+			<substring>Short Orcish Zatoichi</substring>
+			<identifier>Tanto</identifier>
+		</binding>
+		<binding>
+			<substring>Short Elven Zatoichi</substring>
 			<identifier>Tanto</identifier>
 		</binding>
 	<!-- Tanto bindings end -->

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -5675,6 +5675,10 @@
 			<substring>HoarFrost</substring>
 			<identifier>Dagger</identifier>
 		</binding>
+		<binding>
+			<substring>Shards of Narsil</substring>
+			<identifier>Dagger</identifier>
+		</binding>
 	<!-- Dagger bindings end -->
 
 	<!-- Hatchet bindings start -->

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -854,6 +854,10 @@
 			<substring>Norse</substring>
 		</binding>
 		<binding>
+			<identifier>Nord</identifier>
+			<substring>VanNord</substring>
+		</binding>
+		<binding>
 			<identifier>Advanced</identifier>
 			<substring>Regent's</substring>
 		</binding>
@@ -7379,6 +7383,10 @@
 		</binding>
 		<binding>
 			<substring>Bow of the Forgotten Chaos</substring>
+			<identifier>Longbow</identifier>
+		</binding>
+		<binding>
+			<substring>VanNord Bow</substring>
 			<identifier>Longbow</identifier>
 		</binding>
 	<!-- Longbow bindings end -->


### PR DESCRIPTION
Bindings for InsanitySorrow's Zatoichi(26619) (I'm unsure if there is support for have a prefix before and after?)
Bindings for Vayan Armor(61616)
Bindings for Belko(62149)'s Default gear.
Bindings for VanNord Carved Nordic Armour(64560)
Leveled List Exclusions for VanNord Carved Nordic Armour,Vayan(female only) and Belko's Gear.(ignore LL Zatoichi was mistype on heading)
Deadric Crescent Fixed(Immersive Weapons has a 2H and 1H(named the same as LWE 2H) so they are basically incompatible)
Aetherium Armor and Weapons Compilation(23530) Fixes(Dwarven Power Battlexe is how it is in the replacement esp....bolt launcher was missing)
Isilmeriel LOTR Weapons Collection Fix(missing dagger and LL Exclusions)

(Wonder how much i can cram into this patch before you merge it :P)
