### PR TITLE
Mystic Elven Armor,Divine Aegis Support.

### DIFF
--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Ammunition.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Ammunition.xml
@@ -1075,6 +1075,12 @@
 			<substring>VanNord</substring>
 		</binding>
 	<!-- VanNord -->
+	<!-- Mystic Elven -->
+		<binding>
+			<identifier>DaedricNoMult</identifier>
+			<substring>Mystic Elven</substring>
+		</binding>
+	<!-- Mystic Elven -->
 	</ammunition_material_bindings>
 
 	<ammunition_exclusions_multiplication>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
@@ -1850,6 +1850,10 @@
 			<identifier>Daedric</identifier>
 			<substring>H8</substring>
 		</binding>
+		<binding>
+			<identifier>DaedricLight</identifier>
+			<substring>Mystic Elven</substring>
+		</binding>
 	<!-- Daedric Material Bindings end -->
 	
 	<!-- Dragonplate Material Bindings start -->

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
@@ -1854,6 +1854,10 @@
 			<identifier>DaedricLight</identifier>
 			<substring>Mystic Elven</substring>
 		</binding>
+		<binding>
+			<identifier>Daedric</identifier>
+			<substring>Divine Aegis</substring>
+		</binding>
 	<!-- Daedric Material Bindings end -->
 	
 	<!-- Dragonplate Material Bindings start -->

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -3361,13 +3361,20 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Isilmeriel LOTR Weapons Collection -->
-		<!-- MysticElven -->
+		<!-- Mystic Elven -->
 			<exclusion>
 				<text>MysticElven</text>
 				<target>EDID</target>
 				<type>STARTSWITH</type>
 			</exclusion>
-		<!-- MysticElven -->
+		<!-- Mystic Elven -->
+		<!-- Divine Aegis -->
+			<exclusion>
+				<text>xxGreatTemplar</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Divine Aegis -->
 		</distribution_exclusions_weapon_regular>
 
 		<distribution_exclusions_list_regular>
@@ -3656,7 +3663,6 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Spears By Soolie -->
-		
 		</distribution_exclusions_list_regular>
 
 		<distribution_exclusions_weapon_enchanted>
@@ -4617,13 +4623,20 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Isilmeriel LOTR Weapons Collection -->
-		<!-- MysticElven -->
+		<!-- Mystic Elven -->
 			<exclusion>
 				<text>MysticElven</text>
 				<target>EDID</target>
 				<type>STARTSWITH</type>
 			</exclusion>
-		<!-- MysticElven -->
+		<!-- Mystic Elven -->
+		<!-- Divine Aegis -->
+			<exclusion>
+				<text>xxGreatTemplar</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Divine Aegis -->
 		</distribution_exclusions_weapon_enchanted>
 
 		<distribution_exclusions_list_enchanted>
@@ -6338,13 +6351,25 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- VanNord -->
-		<!-- MysticElven -->
+		<!-- Mystic Elven -->
 			<exclusion>
 				<text>MysticElven</text>
 				<target>EDID</target>
 				<type>STARTSWITH</type>
 			</exclusion>
-		<!-- MysticElven -->
+		<!-- Mystic Elven -->
+		<!-- Divine Aegis -->
+			<exclusion>
+				<text>DivineAegis</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+			<exclusion>
+				<text>AegisCloak</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Divine Aegis -->
 		</distribution_exclusions_armor_regular>
 
 		<distribution_exclusions_list_regular>
@@ -7825,13 +7850,25 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- VanNord -->
-		<!-- MysticElven -->
+		<!-- Mystic Elven -->
 			<exclusion>
 				<text>MysticElven</text>
 				<target>EDID</target>
 				<type>STARTSWITH</type>
 			</exclusion>
-		<!-- MysticElven -->
+		<!-- Mystic Elven -->
+		<!-- Divine Aegis -->
+			<exclusion>
+				<text>DivineAegis</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+			<exclusion>
+				<text>AegisCloak</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Divine Aegis -->
 		</distribution_exclusions_armor_enchanted>
 
 		<distribution_exclusions_list_enchanted>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -3361,6 +3361,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Isilmeriel LOTR Weapons Collection -->
+		<!-- MysticElven -->
+			<exclusion>
+				<text>MysticElven</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- MysticElven -->
 		</distribution_exclusions_weapon_regular>
 
 		<distribution_exclusions_list_regular>
@@ -4610,6 +4617,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Isilmeriel LOTR Weapons Collection -->
+		<!-- MysticElven -->
+			<exclusion>
+				<text>MysticElven</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- MysticElven -->
 		</distribution_exclusions_weapon_enchanted>
 
 		<distribution_exclusions_list_enchanted>
@@ -6324,6 +6338,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- VanNord -->
+		<!-- MysticElven -->
+			<exclusion>
+				<text>MysticElven</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- MysticElven -->
 		</distribution_exclusions_armor_regular>
 
 		<distribution_exclusions_list_regular>
@@ -7804,6 +7825,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- VanNord -->
+		<!-- MysticElven -->
+			<exclusion>
+				<text>MysticElven</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- MysticElven -->
 		</distribution_exclusions_armor_enchanted>
 
 		<distribution_exclusions_list_enchanted>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -1271,6 +1271,10 @@
 			<identifier>Daedric</identifier>
 			<substring>Mystic Elven</substring>
 		</binding>
+		<binding>
+			<identifier>Daedric</identifier>
+			<substring>Divine Aegis</substring>
+		</binding>
 	<!-- Daedric bindings end -->
 	
 	<!-- Dragonplate bindings start -->
@@ -5405,6 +5409,10 @@
 		</binding>
 		<binding>
 			<substring>Daedric Crescent - Short</substring>
+			<identifier>Arming Sword</identifier>
+		</binding>
+		<binding>
+			<substring>Sword of the Divine Aegis</substring>
 			<identifier>Arming Sword</identifier>
 		</binding>
 	<!-- Arming Sword bindings end -->

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -1267,6 +1267,10 @@
 			<identifier>Daedric</identifier>
 			<substring>Ancient Tongue</substring>
 		</binding>
+		<binding>
+			<identifier>Daedric</identifier>
+			<substring>Mystic Elven</substring>
+		</binding>
 	<!-- Daedric bindings end -->
 	
 	<!-- Dragonplate bindings start -->
@@ -7403,6 +7407,10 @@
 		</binding>
 		<binding>
 			<substring>VanNord Bow</substring>
+			<identifier>Longbow</identifier>
+		</binding>
+		<binding>
+			<substring>Mystic Elven Bow</substring>
 			<identifier>Longbow</identifier>
 		</binding>
 	<!-- Longbow bindings end -->


### PR DESCRIPTION
Binding and LL Exclusions for 'Mystic Elven Armor - HD' (5600).
Binding and LL Exclusions for 'Divine Aegis HD' (9109).
Set all to Daedric(ME as Light,DA as Heavy) as that is what the original stats were tuned at.

(If you see anything wrong let me know but for now I'll be doing some uni work.)
