### PR TITLE
Altmer ESO Armor Reborn, Dwemer Spectres,Black Horse Courier,Liliths Obliterator

### DIFF
--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
@@ -2554,6 +2554,10 @@
 			<identifier>Dwarven</identifier>
 			<substring>Heavy Ruby</substring>
 		</binding>
+		<binding>
+			<identifier>Dwarven</identifier>
+			<substring>Helm of the Aethernaut</substring>
+		</binding>
 	<!-- Dwarven Material Bindings end -->
 	
 	<!-- Ebony Material Bindings start -->

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
@@ -659,6 +659,10 @@
 			<identifier>Clothing</identifier>
 			<substring>Thalmor Wings</substring>
 		</binding>
+		<binding>
+			<identifier>Elven</identifier>
+			<substring>Altmer</substring>
+		</binding>
 	<!-- Racial material_Bindings end -->
 	
 	<!-- Faction material_Bindings start -->

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -1801,6 +1801,18 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Dwemer Spectres -->
+		<!-- Black Horse Courier Reborn -->
+			<exclusion>
+				<text>_SAG_BlackHorse</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+			<exclusion>
+				<text>_SAG_BHC</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Black Horse Courier Reborn -->
 		</distribution_exclusions_book>
 
 		<distribution_exclusions_list>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -320,14 +320,7 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Hearthfire multiple adoptions end -->
-		<!-- Brhuce: Legacy -->
-			<exclusion>
-				<text>_tw_</text>
-				<target>EDID</target>
-				<type>STARTSWITH</type>
-			</exclusion>
-		<!-- Brhuce: Legacy -->
-		<!-- World Eater Beater -->
+		<!-- World Eater Beater and Bhruce Legacy -->
 			<exclusion>
 				<text>_tw_</text>
 				<target>EDID</target>
@@ -343,7 +336,7 @@
 				<target>EDID</target>
 				<type>STARTSWITH</type>
 			</exclusion>
-		<!-- World Eater Beater -->
+		<!-- World Eater Beater and Bhruce Legacy -->
 		<!-- Lost Wonders of Mzark -->
 			<exclusion>
 				<text>_lw_</text>
@@ -1801,6 +1794,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Campfire -->
+		<!-- Dwemer Spectres -->
+			<exclusion>
+				<text>_tw_</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Dwemer Spectres -->
 		</distribution_exclusions_book>
 
 		<distribution_exclusions_list>
@@ -4698,6 +4698,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Yharnyam Set -->
+		<!-- Dwemer Spectres -->
+			<exclusion>
+				<text>_tw_</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- Dwemer Spectres -->
 		</distribution_exclusions_weapon_enchanted>
 
 		<distribution_exclusions_list_enchanted>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -1299,6 +1299,22 @@
 			<identifier>Daedric</identifier>
 			<substring>Firelink</substring>
 		</binding>
+		<binding>
+			<identifier>Daedric</identifier>
+			<substring>Lilith's Obliterator</substring>
+		</binding>'
+		<binding>
+			<identifier>Daedric</identifier>
+			<substring>Lilith's Evening Star</substring>
+		</binding>
+		<binding>
+			<identifier>DaedricHigh</identifier>
+			<substring>Lilith's Ancient Obliterator</substring>
+		</binding>
+		<binding>
+			<identifier>DaedricHigh</identifier>
+			<substring>Lilith's Ancient Evening Star</substring>
+		</binding>
 	<!-- Daedric bindings end -->
 	
 	<!-- Dragonplate bindings start -->
@@ -6166,6 +6182,14 @@
 			<substring>Mace of Molag Bal</substring>
 			<identifier>Spiked Mace</identifier>
 		</binding>
+		<binding>
+			<substring>Lilith's Obliterator (mace1h</substring>
+			<identifier>Longmace</identifier>
+		</binding>
+		<binding>
+			<substring>Lilith's Ancient Obliterator (mace1h</substring>
+			<identifier>Longmace</identifier>
+		</binding>
 	<!-- Mace bindings end -->
 
 	<!-- Maul bindings start -->
@@ -6179,7 +6203,7 @@
 		</binding>
 	<!-- Maul bindings end -->
 	
-	<!-- Morning Star -->
+	<!-- Morning Star bindings start -->
 		<binding>
 			<substring>Morning star</substring>
 			<identifier>Morning Star</identifier>
@@ -6192,7 +6216,14 @@
 			<substring>Emfy Mace</substring>
 			<identifier>Morning Star</identifier>
 		</binding>
-	<!-- Morning Star -->
+		<binding>
+			<substring>Lilith's Evening Star (1h)</substring>
+			<identifier>Morning Star</identifier>
+		</binding>
+		<binding>
+			<substring>Lilith's Ancient Evening Star (1h)</substring>
+			<identifier>Morning Star</identifier>
+	<!-- Morning Star bindings end -->
 
 	<!-- Sabre bindings start -->
 		<binding>
@@ -6540,6 +6571,14 @@
 			<substring>Natat</substring>
 			<identifier>Waraxe</identifier>
 		</binding>
+		<binding>
+			<substring>Lilith's Obliterator (1h</substring>
+			<identifier>Waraxe</identifier>
+		</binding>
+		<binding>
+			<substring>Lilith's Ancient Obliterator (1h</substring>
+			<identifier>Waraxe</identifier>
+		</binding>
 	<!-- Waraxe bindings end -->
 	<!-- =====================================================Light Weapon bindings end =================================================== -->
 
@@ -6750,6 +6789,14 @@
 		</binding>
 		<binding>
 			<substring>Cloudcleaver</substring>
+			<identifier>Battleaxe</identifier>
+		</binding>
+		<binding>
+			<substring>Lilith's Obliterator</substring>
+			<identifier>Battleaxe</identifier>
+		</binding>
+		<binding>
+			<substring>Lilith's Ancient Obliterator</substring>
 			<identifier>Battleaxe</identifier>
 		</binding>
 	<!-- Battleaxe bindings end -->
@@ -7129,6 +7176,14 @@
 	<!-- Greatsword bindings end -->
 	
 	<!-- Halberd bindings start -->
+		<binding>
+			<substring>Lilith's Obliterator (halbert)</substring>
+			<identifier>Halberd</identifier>
+		</binding>
+		<binding>
+			<substring>Lilith's Ancient Obliterator (halbert)</substring>
+			<identifier>Halberd</identifier>
+		</binding>
 	<!-- Halberd bindings end -->
 	
 	<!-- Longmace bindings start -->
@@ -7146,6 +7201,14 @@
 		</binding>
 		<binding>
 			<substring>Black Ice</substring>
+			<identifier>Longmace</identifier>
+		</binding>
+		<binding>
+			<substring>Lilith's Obliterator (mace</substring>
+			<identifier>Longmace</identifier>
+		</binding>
+		<binding>
+			<substring>Lilith's Ancient Obliterator (mace</substring>
 			<identifier>Longmace</identifier>
 		</binding>
 	<!-- Longmace bindings end -->
@@ -7368,6 +7431,14 @@
 	<!-- Great Morning Star bindings start -->
 		<binding>
 			<substring>War Morning Star</substring>
+			<identifier>Great Morning Star</identifier>
+		</binding>
+		<binding>
+			<substring>Lilith's Evening Star (2h)</substring>
+			<identifier>Great Morning Star</identifier>
+		</binding>
+		<binding>
+			<substring>Lilith's Ancient Evening Star (2h)</substring>
 			<identifier>Great Morning Star</identifier>
 		</binding>
 	<!-- Great Morning Star bindings end -->

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -1807,6 +1807,14 @@
 			<identifier>Dwarven</identifier>
 			<substring>Atulg's Edge</substring>
 		</binding>
+		<binding>
+			<identifier>Dwarven</identifier>
+			<substring>Nullsprocket</substring>
+		</binding>
+		<binding>
+			<identifier>Dwarven</identifier>
+			<substring>Clutterbane</substring>
+		</binding>
 	<!-- Dwarven bindings end -->
 	
 	<!-- Ebony bindings start -->
@@ -8702,7 +8710,7 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Wheels Of Lull-->
-	<!-- Brhuce: Legacy also affects Blackreach Railroad-->
+	<!-- Brhuce: Legacy also affects Blackreach Railroad and Dwemer Spectres-->
 		<exclusion>
 			<text>_tw_</text>
 			<target>EDID</target>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -3149,10 +3149,6 @@
 			<substring>Refined Luna</substring>
 		</binding>
 		<binding>
-			<identifier>Silver</identifier>
-			<substring>Luna II</substring>
-		</binding>
-		<binding>
 			<identifier>RSilver</identifier>
 			<substring>Refined Luna II</substring>
 		</binding>
@@ -5241,10 +5237,6 @@
 			<identifier>Arming Sword</identifier>
 		</binding>
 		<binding>
-			<substring>Soulrender</substring>
-			<identifier>Arming Sword</identifier>
-		</binding>
-		<binding>
 			<substring>Albensword</substring>
 			<identifier>Arming Sword</identifier>
 		</binding>
@@ -6244,6 +6236,10 @@
 		</binding>
 		<binding>
 			<substring>Bloodscythe</substring>
+			<identifier>Scimitar</identifier>
+		</binding>
+		<binding>
+			<substring>Soulrender</substring>
 			<identifier>Scimitar</identifier>
 		</binding>
 		<binding>


### PR DESCRIPTION
issue #390 
issue #284 
issue #222 
issue #412 

Altmer armor seemed easy enough, I put it with Racial Bindings and did not add it to leveledlist exclusions as you mentioned it may be distributed in issue.
Dwemer Spectres had a lot of intersecting exclusions with other trainwiz mods, but nothing seemed to cause any problems.
Added leveledlist exclusion for Black Horse Courier books, didn't seem to need much else.
Lilith's Obliterators bindings are kind of ugly, I know, but there's 30 variants so I made some compromises.
Cleaned up extra luna binding and put soulrender with it's proper place among scimitars.
