### PR TITLE
Merp's Gondorian Armory, Bosmer Ceremonial Armor

### DIFF
--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Ammunition.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Ammunition.xml
@@ -1087,6 +1087,12 @@
 			<substring>Cynder</substring>
 		</binding>
 	<!-- Cynder Arrows -->
+	<!-- Merp's Gondorian Armor -->
+		<binding>
+			<identifier>Steel</identifier>
+			<substring>Gondorian</substring>
+		</binding>
+	<!-- Merp's Gondorian Armor -->
 	</ammunition_material_bindings>
 
 	<ammunition_exclusions_multiplication>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Armor.xml
@@ -1120,6 +1120,18 @@
 			<identifier>HeavyFactionHigh</identifier>
 			<substring>Dragonguard Helmet</substring>
 		</binding>
+		<binding>
+			<identifier>HeavyFactionHigh</identifier>
+			<substring>Tower Guard</substring>
+		</binding>
+		<binding>
+			<identifier>HeavyFaction</identifier>
+			<substring>Citadel Guard</substring>
+		</binding>
+		<binding>
+			<identifier>HeavyFaction</identifier>
+			<substring>Gondorian</substring>
+		</binding>
 	<!-- Faction material_Bindings end -->
 	
 	<!-- Civil War material_Bindings Start -->
@@ -4026,6 +4038,10 @@
 		<binding>
 			<identifier>Glass</identifier>
 			<substring>Emerald</substring>
+		</binding>
+		<binding>
+			<identifier>Glass</identifier>
+			<substring>Bosmer Ceremonial</substring>
 		</binding>
 	<!-- Glass Material Bindings end -->
 	

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Enchanting.xml
@@ -8864,6 +8864,13 @@
 			<type>STARTSWITH</type>
 		</exclusion>
 	<!-- Yharnyam Set -->
+	<!-- ESO Altmer Armor by NewerMind43 RELOAD -->
+		<exclusion>
+			<text>xxxESOAltmer</text>
+			<target>EDID</target>
+			<type>STARTSWITH</type>
+		</exclusion>
+	<!-- ESO Altmer Armor by NewerMind43 RELOAD -->
 	</enchantment_armor_exclusions>
 
 	<similarity_exclusions_armor>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -6471,6 +6471,13 @@
 				<type>STARTSWITH</type>
 			</exclusion>
 		<!-- Yharnyam Set -->
+		<!-- ESO Altmer Armor by NewerMind43 RELOAD -->
+			<exclusion>
+				<text>xxxESOAltmer</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
+		<!-- ESO Altmer Armor by NewerMind43 RELOAD -->
 		</distribution_exclusions_armor_regular>
 
 		<distribution_exclusions_list_regular>

--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/Weapons.xml
@@ -7228,10 +7228,6 @@
 			<identifier>Nodachi</identifier>
 		</binding>
 		<binding>
-			<substring>Ebony Blade</substring>
-			<identifier>Nodachi</identifier>
-		</binding>
-		<binding>
 			<substring>Akaviri Greatsword</substring>
 			<identifier>Nodachi</identifier>
 		</binding>
@@ -7284,6 +7280,14 @@
 		</binding>
 		<binding>
 			<identifier>Spear Of Thorns</identifier>
+			<substring>Partisan</substring>
+		</binding>
+		<binding>
+			<identifier>Gondorian Spear</identifier>
+			<substring>Partisan</substring>
+		</binding>
+		<binding>
+			<identifier>Spear of the Tower Guard</identifier>
 			<substring>Partisan</substring>
 		</binding>
 	<!-- Partisan bindings end -->
@@ -7740,6 +7744,10 @@
 		<binding>
 			<substring>Throw Javelins</substring>
 			<identifier>Javelin</identifier>
+		</binding>
+		<binding>
+			<substring>Gondorian Bow</substring>
+			<identifier>Shortbow</identifier>
 		</binding>
 	<!-- Shortbow bindings end -->
 	


### PR DESCRIPTION
#396
#417

Added leveledlist and enchantment exclusions to ESO Altmer armor as it lacks a proper male model
Removed a duplicate binding for the ebony blade
