### PR TITLE
Added exclusion for Nock to Tip recurve bows

### DIFF
--- a/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
+++ b/SkyProc Patchers/T3nd0_PatchusMaximus/PMxml/LeveledLists.xml
@@ -2974,6 +2974,11 @@
 				<target>EDID</target>
 				<type>STARTSWITH</type>
 			</exclusion>
+			<exclusion>
+				<text>RecurveBow</text>
+				<target>EDID</target>
+				<type>STARTSWITH</type>
+			</exclusion>
 		<!-- Nock to Tip end -->
 		<!-- Death Alternative -->
 			<exclusion>


### PR DESCRIPTION
Pama Patcher was flooding the leveled lists with RecurveBow (Bryte'ned bow) variants.

LItemWeaponBow for example was being bloated out to 140+ entries.
